### PR TITLE
Fix pet named unknown after teleport.

### DIFF
--- a/src/game/Handlers/MovementHandler.cpp
+++ b/src/game/Handlers/MovementHandler.cpp
@@ -247,7 +247,7 @@ void WorldSession::HandleMoveTeleportAckOpcode(WorldPacket& recv_data)
     plMover->TeleportPositionRelocation(dest.coord_x, dest.coord_y, dest.coord_z, dest.orientation);
 
     // resummon pet, if the destination is in another continent instance, let Player::SwitchInstance do it
-    // because the client will request the name for the old pet guid and receive the answer after the pet change
+    // because the client will request the name for the old pet guid and receive no answer
     // result would be a pet named "unknown"
     if (plMover->GetTemporaryUnsummonedPetNumber())
         if (sWorld.getConfig(CONFIG_BOOL_CONTINENTS_INSTANCIATE) && plMover->GetMap()->IsContinent())

--- a/src/game/Handlers/MovementHandler.cpp
+++ b/src/game/Handlers/MovementHandler.cpp
@@ -246,8 +246,18 @@ void WorldSession::HandleMoveTeleportAckOpcode(WorldPacket& recv_data)
     WorldLocation const& dest = plMover->GetTeleportDest();
     plMover->TeleportPositionRelocation(dest.coord_x, dest.coord_y, dest.coord_z, dest.orientation);
 
-    // resummon pet
-    plMover->ResummonPetTemporaryUnSummonedIfAny();
+    // resummon pet, if the destination is in another continent instance, let Player::SwitchInstance do it
+    // because the client will request the name for the old pet guid and receive the answer after the pet change
+    // result would be a pet named "unknown"
+    if (plMover->GetTemporaryUnsummonedPetNumber())
+        if (sWorld.getConfig(CONFIG_BOOL_CONTINENTS_INSTANCIATE) && plMover->GetMap()->IsContinent())
+        {
+            bool transition = false;
+            if (sMapMgr.GetContinentInstanceId(plMover->GetMap()->GetId(), dest.coord_x, dest.coord_y, &transition) == plMover->GetInstanceId())
+                plMover->ResummonPetTemporaryUnSummonedIfAny();
+        }
+        else
+            plMover->ResummonPetTemporaryUnSummonedIfAny();
 
     //lets process all delayed operations on successful teleport
     plMover->ProcessDelayedOperations();


### PR DESCRIPTION
The pet was resummoned after a teleport on the same continent and then again unsummoned and resummoned if an instance switch was needed.
Apparently it's a too short time between both operations, the client would request the name for the old pet guid and receive no answer.