### PR TITLE
Implemented round robin rules to quest and conditional items

### DIFF
--- a/src/game/Group/Group.cpp
+++ b/src/game/Group/Group.cpp
@@ -910,17 +910,17 @@ void Group::StartLootRoll(Creature* lootTarget, LootMethod method, Loot* loot, u
         r->setLoot(loot);
         r->itemSlot = itemSlot;
 
-		if (r->totalPlayersRolling == 1)                    // single looter
-		{
-			r->playerVote.begin()->second = ROLL_NEED;
-			CountSingleLooterRoll(r);
-		}
+        if (r->totalPlayersRolling == 1)                    // single looter
+        {
+            r->playerVote.begin()->second = ROLL_NEED;
+            CountSingleLooterRoll(r);
+        }
         else
         {
             SendLootStartRoll(LOOT_ROLL_TIMEOUT, *r);
             loot->items[itemSlot].is_blocked = true;
             lootTarget->StartGroupLoot(this, LOOT_ROLL_TIMEOUT);
-			RollId.push_back(r);
+            RollId.push_back(r);
         }
     }
     else                                            // no looters??
@@ -981,34 +981,34 @@ void Group::EndRoll(Loot* loot)
 
 void Group::CountSingleLooterRoll(Roll* roll)
 {
-	ObjectGuid playerGuid = roll->playerVote.begin()->first;
-	Player* player = sObjectMgr.GetPlayer(playerGuid);
-	SendLootRollWon(playerGuid, uint8(100), ROLL_NEED, *roll);
+    ObjectGuid playerGuid = roll->playerVote.begin()->first;
+    Player* player = sObjectMgr.GetPlayer(playerGuid);
+    SendLootRollWon(playerGuid, uint8(100), ROLL_NEED, *roll);
 
-	LootItem *item = &(roll->getLoot()->items[roll->itemSlot]);
-	if (player && player->GetSession())
-	{
-		ItemPosCountVec dest;
-		InventoryResult msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, roll->itemid, item->count);
-		if (msg == EQUIP_ERR_OK)
-		{
-			item->is_looted = true;
-			roll->getLoot()->NotifyItemRemoved(roll->itemSlot);
-			--roll->getLoot()->unlootedCount;
-			sLog.out(LOG_LOOTS, "%s wins need roll for %ux%u [loot from %s]",
-				player->GetShortDescription().c_str(), item->count, item->itemid, roll->lootedTargetGUID.GetString().c_str());
-			if (Item* newItem = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId))
-				player->OnReceivedItem(newItem);
-		}
-		else
-		{
-			item->is_blocked = false;
-			item->lootOwner = playerGuid;
-			player->SendEquipError(msg, NULL, NULL, roll->itemid);
-		}
-	}
+    LootItem *item = &(roll->getLoot()->items[roll->itemSlot]);
+    if (player && player->GetSession())
+    {
+        ItemPosCountVec dest;
+        InventoryResult msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, roll->itemid, item->count);
+        if (msg == EQUIP_ERR_OK)
+        {
+            item->is_looted = true;
+            roll->getLoot()->NotifyItemRemoved(roll->itemSlot);
+            --roll->getLoot()->unlootedCount;
+            sLog.out(LOG_LOOTS, "%s wins need roll for %ux%u [loot from %s]",
+                player->GetShortDescription().c_str(), item->count, item->itemid, roll->lootedTargetGUID.GetString().c_str());
+            if (Item* newItem = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId))
+                player->OnReceivedItem(newItem);
+        }
+        else
+        {
+            item->is_blocked = false;
+            item->lootOwner = playerGuid;
+            player->SendEquipError(msg, NULL, NULL, roll->itemid);
+        }
+    }
 
-	delete roll;
+    delete roll;
 }
 
 void Group::CountTheRoll(Rolls::iterator& rollI)

--- a/src/game/Group/Group.cpp
+++ b/src/game/Group/Group.cpp
@@ -910,16 +910,18 @@ void Group::StartLootRoll(Creature* lootTarget, LootMethod method, Loot* loot, u
         r->setLoot(loot);
         r->itemSlot = itemSlot;
 
-        if (r->totalPlayersRolling == 1)                    // single looter
-            r->playerVote.begin()->second = ROLL_NEED;
+		if (r->totalPlayersRolling == 1)                    // single looter
+		{
+			r->playerVote.begin()->second = ROLL_NEED;
+			CountSingleLooterRoll(r);
+		}
         else
         {
             SendLootStartRoll(LOOT_ROLL_TIMEOUT, *r);
             loot->items[itemSlot].is_blocked = true;
             lootTarget->StartGroupLoot(this, LOOT_ROLL_TIMEOUT);
+			RollId.push_back(r);
         }
-
-        RollId.push_back(r);
     }
     else                                            // no looters??
         delete r;
@@ -975,6 +977,38 @@ void Group::EndRoll(Loot* loot)
         else
             itr++;
     }
+}
+
+void Group::CountSingleLooterRoll(Roll* roll)
+{
+	ObjectGuid playerGuid = roll->playerVote.begin()->first;
+	Player* player = sObjectMgr.GetPlayer(playerGuid);
+	SendLootRollWon(playerGuid, uint8(100), ROLL_NEED, *roll);
+
+	LootItem *item = &(roll->getLoot()->items[roll->itemSlot]);
+	if (player && player->GetSession())
+	{
+		ItemPosCountVec dest;
+		InventoryResult msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, roll->itemid, item->count);
+		if (msg == EQUIP_ERR_OK)
+		{
+			item->is_looted = true;
+			roll->getLoot()->NotifyItemRemoved(roll->itemSlot);
+			--roll->getLoot()->unlootedCount;
+			sLog.out(LOG_LOOTS, "%s wins need roll for %ux%u [loot from %s]",
+				player->GetShortDescription().c_str(), item->count, item->itemid, roll->lootedTargetGUID.GetString().c_str());
+			if (Item* newItem = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId))
+				player->OnReceivedItem(newItem);
+		}
+		else
+		{
+			item->is_blocked = false;
+			item->lootOwner = playerGuid;
+			player->SendEquipError(msg, NULL, NULL, roll->itemid);
+		}
+	}
+
+	delete roll;
 }
 
 void Group::CountTheRoll(Rolls::iterator& rollI)

--- a/src/game/Group/Group.h
+++ b/src/game/Group/Group.h
@@ -421,6 +421,7 @@ class MANGOS_DLL_SPEC Group
                 --m_subGroupsCounts[subgroup];
         }
 
+		void CountSingleLooterRoll(Roll* roll);
         void CountTheRoll(Rolls::iterator& roll);           // iterator update to next, in CountRollVote if true
         bool CountRollVote(ObjectGuid const& playerGUID, Rolls::iterator& roll, RollVote vote);
 

--- a/src/game/Group/Group.h
+++ b/src/game/Group/Group.h
@@ -421,7 +421,7 @@ class MANGOS_DLL_SPEC Group
                 --m_subGroupsCounts[subgroup];
         }
 
-		void CountSingleLooterRoll(Roll* roll);
+        void CountSingleLooterRoll(Roll* roll);
         void CountTheRoll(Rolls::iterator& roll);           // iterator update to next, in CountRollVote if true
         bool CountRollVote(ObjectGuid const& playerGUID, Rolls::iterator& roll, RollVote vote);
 

--- a/src/game/LootMgr.cpp
+++ b/src/game/LootMgr.cpp
@@ -835,7 +835,7 @@ ByteBuffer& operator<<(ByteBuffer& b, LootView const& lv)
         case GROUP_PERMISSION:
         {
             // if you are not the round-robin group looter, you can only see
-			// blocked rolled items and !ffa items
+            // blocked rolled items and !ffa items
             for (uint8 i = 0; i < l.items.size(); ++i)
             {
                 if (!l.items[i].is_looted && !l.items[i].freeforall && l.items[i].AllowedForPlayer(lv.viewer, l.GetLootTarget()))
@@ -922,21 +922,21 @@ ByteBuffer& operator<<(ByteBuffer& b, LootView const& lv)
         QuestItemList *q_list = q_itr->second;
         for (QuestItemList::const_iterator qi = q_list->begin() ; qi != q_list->end(); ++qi)
         {
-			LootItem &item = l.m_questItems[qi->index];
+            LootItem &item = l.m_questItems[qi->index];
 
-			if (qi->is_looted || item.is_looted)
-				continue;
+            if (qi->is_looted || item.is_looted)
+                continue;
 
-			// Allow only the round robin player unless that player is not elligible for item
-			if (!item.freeforall && l.roundRobinPlayer != 0 && lv.viewer->GetGUID() != l.roundRobinPlayer
-				&& lootPlayerQuestItems.find(l.roundRobinPlayer) != lootPlayerQuestItems.end())
-				continue;
+            // Allow only the round robin player unless that player is not elligible for item
+            if (!item.freeforall && l.roundRobinPlayer != 0 && lv.viewer->GetGUID() != l.roundRobinPlayer
+                && lootPlayerQuestItems.find(l.roundRobinPlayer) != lootPlayerQuestItems.end())
+                continue;
 
-			// allow loot
-			b << uint8(l.items.size() + (qi - q_list->begin()));
-			b << item;
-			b << uint8(slot_type);
-			++itemsShown;
+            // allow loot
+            b << uint8(l.items.size() + (qi - q_list->begin()));
+            b << item;
+            b << uint8(slot_type);
+            ++itemsShown;
         }
     }
 
@@ -970,10 +970,10 @@ ByteBuffer& operator<<(ByteBuffer& b, LootView const& lv)
             if (slot_type >= MAX_LOOT_SLOT_TYPE)
                 continue;
 
-			// Allow only the round robin player unless that player is not elligible for item
-			if (!item.freeforall && l.roundRobinPlayer != 0 && lv.viewer->GetGUID() != l.roundRobinPlayer
-				&& lootPlayerNonQuestNonFFAConditionalItems.find(l.roundRobinPlayer) != lootPlayerNonQuestNonFFAConditionalItems.end())
-				continue;
+            // Allow only the round robin player unless that player is not elligible for item
+            if (!item.freeforall && l.roundRobinPlayer != 0 && lv.viewer->GetGUID() != l.roundRobinPlayer
+                && lootPlayerNonQuestNonFFAConditionalItems.find(l.roundRobinPlayer) != lootPlayerNonQuestNonFFAConditionalItems.end())
+                continue;
 
             b << uint8(ci->index) << item;
             b << uint8(slot_type);                          // allow loot

--- a/src/game/LootMgr.cpp
+++ b/src/game/LootMgr.cpp
@@ -835,7 +835,7 @@ ByteBuffer& operator<<(ByteBuffer& b, LootView const& lv)
         case GROUP_PERMISSION:
         {
             // if you are not the round-robin group looter, you can only see
-            // blocked rolled items and quest items, and !ffa items
+			// blocked rolled items and !ffa items
             for (uint8 i = 0; i < l.items.size(); ++i)
             {
                 if (!l.items[i].is_looted && !l.items[i].freeforall && l.items[i].AllowedForPlayer(lv.viewer, l.GetLootTarget()))
@@ -922,14 +922,21 @@ ByteBuffer& operator<<(ByteBuffer& b, LootView const& lv)
         QuestItemList *q_list = q_itr->second;
         for (QuestItemList::const_iterator qi = q_list->begin() ; qi != q_list->end(); ++qi)
         {
-            LootItem &item = l.m_questItems[qi->index];
-            if (!qi->is_looted && !item.is_looted)
-            {
-                b << uint8(l.items.size() + (qi - q_list->begin()));
-                b << item;
-                b << uint8(slot_type);                      // allow loot
-                ++itemsShown;
-            }
+			LootItem &item = l.m_questItems[qi->index];
+
+			if (qi->is_looted || item.is_looted)
+				continue;
+
+			// Allow only the round robin player unless that player is not elligible for item
+			if (!item.freeforall && l.roundRobinPlayer != 0 && lv.viewer->GetGUID() != l.roundRobinPlayer
+				&& lootPlayerQuestItems.find(l.roundRobinPlayer) != lootPlayerQuestItems.end())
+				continue;
+
+			// allow loot
+			b << uint8(l.items.size() + (qi - q_list->begin()));
+			b << item;
+			b << uint8(slot_type);
+			++itemsShown;
         }
     }
 
@@ -962,6 +969,11 @@ ByteBuffer& operator<<(ByteBuffer& b, LootView const& lv)
             slot_type = item.GetSlotTypeForSharedLoot(lv.permission, lv.viewer, l.GetLootTarget(), !ci->is_looted);
             if (slot_type >= MAX_LOOT_SLOT_TYPE)
                 continue;
+
+			// Allow only the round robin player unless that player is not elligible for item
+			if (!item.freeforall && l.roundRobinPlayer != 0 && lv.viewer->GetGUID() != l.roundRobinPlayer
+				&& lootPlayerNonQuestNonFFAConditionalItems.find(l.roundRobinPlayer) != lootPlayerNonQuestNonFFAConditionalItems.end())
+				continue;
 
             b << uint8(ci->index) << item;
             b << uint8(slot_type);                          // allow loot


### PR DESCRIPTION
Quest and conditional items now follow round robin rules, just like the other white quality items.

Also fixed the group roll for items where only 1 player is eligible, this fixes Corrupted Scourgestones not being lootable if only one player has the trinket.

Left out the commit that reserved the loot a player won through greed roll but couldn't take due to bags full, since you had some doubts on it:  
https://github.com/GuybrushGit/server-1/commit/4172d305828fb25ac928e4f56994f4d5e128e8ea
Loot won through need roll is already being reserved.
