### PR TITLE
Fix walk mode forced after polymorph followed by death coil.

### DIFF
--- a/src/game/Movement/spline/MoveSplineInit.cpp
+++ b/src/game/Movement/spline/MoveSplineInit.cpp
@@ -174,9 +174,7 @@ int32 MoveSplineInit::Launch()
     // Do not forget to restore velocity after movement !
     if (args.velocity > 4 * realSpeedRun && !args.flags.done)
         mvtData.SetUnitSpeed(SMSG_SPLINE_SET_RUN_SPEED, unit.GetObjectGuid(), realSpeedRun);
-    // Restore correct walk mode for players
-    if (unit.GetTypeId() == TYPEID_PLAYER && (moveFlags & MOVEFLAG_WALK_MODE) != (oldMoveFlags & MOVEFLAG_WALK_MODE))
-        mvtData.SetSplineOpcode(oldMoveFlags & MOVEFLAG_WALK_MODE ? SMSG_SPLINE_MOVE_SET_WALK_MODE : SMSG_SPLINE_MOVE_SET_RUN_MODE, unit.GetObjectGuid());
+
     if (compress)
     {
         WorldPacket data2;

--- a/src/game/Movement/spline/MoveSplineInit.cpp
+++ b/src/game/Movement/spline/MoveSplineInit.cpp
@@ -174,7 +174,11 @@ int32 MoveSplineInit::Launch()
     // Do not forget to restore velocity after movement !
     if (args.velocity > 4 * realSpeedRun && !args.flags.done)
         mvtData.SetUnitSpeed(SMSG_SPLINE_SET_RUN_SPEED, unit.GetObjectGuid(), realSpeedRun);
-
+    // Restore correct walk mode for players
+    // Won't be able to properly restore in case of 2 consecutive splines
+    // Whatever it was before or during the spline, the client will continue in run mode, this could suffice
+    /*if (unit.GetTypeId() == TYPEID_PLAYER && (moveFlags & MOVEFLAG_WALK_MODE) != (oldMoveFlags & MOVEFLAG_WALK_MODE))
+        mvtData.SetSplineOpcode(oldMoveFlags & MOVEFLAG_WALK_MODE ? SMSG_SPLINE_MOVE_SET_WALK_MODE : SMSG_SPLINE_MOVE_SET_RUN_MODE, unit.GetObjectGuid());*/
     if (compress)
     {
         WorldPacket data2;


### PR DESCRIPTION
For players only.
Afaik there's no way to properly restore the walk mode after a spline interrupts another.

The client does something on its own : it always sets run mode as default after a spline.
Example after polymorph or blind spell (confused type movement in walk mode) the player is in run mode even if the server hasn't tried to restore whatever it was. And it doesn't send a MSG_MOVE_SET_RUN_MODE, so no way to track that..