### PR TITLE
Fix Alliance AQ collection pre-quest.

### DIFF
--- a/sql/migrations/20180318191903_world.sql
+++ b/sql/migrations/20180318191903_world.sql
@@ -1,0 +1,21 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180318191903');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180318191903');
+-- Add your query below.
+
+
+-- Fix alliance AQ collection quests prequest.
+UPDATE `creature_questrelation` SET `quest`=8795 WHERE`quest` IN (8796, 8797);
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
On Alliance, the NPCs in Stormwind, Ironforge and Darnassus all give different versions of the prequest, but the collection quests only have the Ironforge one as a previous quest. So if you do the Stormwind or Darnassus version instead, you can never do the collection quests. Making the Stormwind and Darnassus NPCs give the same quest id as the Ironforge NPC solves this, the quests are identical anyway, exact same text and everything, and only one of the 3 versions have comments on allakhazam.

On Horde there is no issue, because the 3 NPCs already give the same quest id.

