### PR TITLE
Temporary weapon enchant durations

### DIFF
--- a/sql/migrations/20180325023821_world.sql
+++ b/sql/migrations/20180325023821_world.sql
@@ -1,0 +1,70 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180325023821');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180325023821');
+-- Add your query below.
+
+
+REPLACE INTO `spell_effect_mod` (`Id`, `EffectBasePoints`, `Comment`) VALUES 
+('2823', '1799', 'Temporary Enchant Duration'),
+('2824', '1799', 'Temporary Enchant Duration'),
+('3594', '1799', 'Temporary Enchant Duration'),
+('6650', '1799', 'Temporary Enchant Duration'),
+('7434', '1799', 'Temporary Enchant Duration'),
+('7439', '3599', 'Temporary Enchant Duration'),
+('7448', '3599', 'Temporary Enchant Duration'),
+('7451', '3599', 'Temporary Enchant Duration'),
+('7769', '3599', 'Temporary Enchant Duration'),
+('7853', '3599', 'Temporary Enchant Duration'),
+('7855', '3599', 'Temporary Enchant Duration'),
+('7865', '3599', 'Temporary Enchant Duration'),
+('8017', '299', 'Temporary Enchant Duration'),
+('8018', '299', 'Temporary Enchant Duration'),
+('8019', '299', 'Temporary Enchant Duration'),
+('8024', '299', 'Temporary Enchant Duration'),
+('8027', '299', 'Temporary Enchant Duration'),
+('8030', '299', 'Temporary Enchant Duration'),
+('8033', '299', 'Temporary Enchant Duration'),
+('8038', '299', 'Temporary Enchant Duration'),
+('8087', '599', 'Temporary Enchant Duration'),
+('8088', '599', 'Temporary Enchant Duration'),
+('8089', '299', 'Temporary Enchant Duration'),
+('8090', '599', 'Temporary Enchant Duration'),
+('8232', '299', 'Temporary Enchant Duration'),
+('8235', '299', 'Temporary Enchant Duration'),
+('8532', '599', 'Temporary Enchant Duration'),
+('8679', '1799', 'Temporary Enchant Duration'),
+('8686', '1799', 'Temporary Enchant Duration'),
+('8688', '1799', 'Temporary Enchant Duration'),
+('9092', '599', 'Temporary Enchant Duration'),
+('10399', '299', 'Temporary Enchant Duration'),
+('10456', '299', 'Temporary Enchant Duration'),
+('10486', '299', 'Temporary Enchant Duration'),
+('11338', '1799', 'Temporary Enchant Duration'),
+('11339', '1799', 'Temporary Enchant Duration'),
+('11340', '1799', 'Temporary Enchant Duration'),
+('11355', '1799', 'Temporary Enchant Duration'),
+('11356', '1799', 'Temporary Enchant Duration'),
+('16314', '299', 'Temporary Enchant Duration'),
+('16315', '299', 'Temporary Enchant Duration'),
+('16316', '299', 'Temporary Enchant Duration'),
+('16339', '299', 'Temporary Enchant Duration'),
+('16341', '299', 'Temporary Enchant Duration'),
+('16342', '299', 'Temporary Enchant Duration'),
+('16355', '299', 'Temporary Enchant Duration'),
+('16356', '299', 'Temporary Enchant Duration'),
+('16362', '299', 'Temporary Enchant Duration'),
+('25351', '1799', 'Temporary Enchant Duration'),
+('28891', '3599', 'Temporary Enchant Duration');
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -3788,44 +3788,7 @@ void Spell::EffectEnchantItemTmp(SpellEffectIndex eff_idx)
         return;
     }
 
-    // select enchantment duration
-    uint32 duration;
-
-    // other rogue family enchantments always 1 hour (some have spell damage=0, but some have wrong data in EffBasePoints)
-    if (m_spellInfo->SpellFamilyName == SPELLFAMILY_ROGUE)
-        duration = 1800;                                    // 30 mins (Ustaag <Nostalrius> : 1h post 2.3)
-    // shaman family enchantments
-    else if (m_spellInfo->SpellFamilyName == SPELLFAMILY_SHAMAN)
-        duration = 300;                                     // 5 mins (Ustaag <Nostalrius> : 30 mn post 1.12)
-    // other cases with this SpellVisual already selected
-    else if (m_spellInfo->SpellVisual == 215)
-        duration = 1800;                                    // 30 mins
-    // some fishing pole bonuses
-    else if (m_spellInfo->SpellVisual == 563)
-        duration = enchant_id == 266 ? 300 : 600;           // 10 or 5 mins
-    // shaman Rockbiter enchantments
-    else if (m_spellInfo->SpellVisual == 58)
-        duration = 300;                                     // 5 mins (Ustaag <Nostalrius> : 30 mn post 1.12)
-    // shaman Flametongue enchantments
-    else if (m_spellInfo->SpellVisual == 290)
-        duration = 300;                                     // 5 mins (Ustaag <Nostalrius> : 30 mn post 1.12)
-    // shaman Frostbrand enchantments
-    else if (m_spellInfo->SpellVisual == 291)
-        duration = 300;                                     // 5 mins (Ustaag <Nostalrius> : 30 mn post 1.12)
-    // Sharpen Blade enchantments
-    else if (m_spellInfo->SpellVisual == 3324)
-        duration = 1800;                                    // 30 mins (Ustaag <Nostalrius> : Sharpening Stone)
-    // Enhance Blunt enchantments
-    else if (m_spellInfo->SpellVisual == 3325)
-        duration = 1800;                                    // 30 mins (Ustaag <Nostalrius> : Weightstone)
-    // Oil enchantments
-    else if (m_spellInfo->SpellVisual == 3182)
-        duration = 1800;                                    // 30 mins (Ustaag <Nostalrius> : Oil)
-    // default case
-    else
-        duration = 3600;                                    // 1 hour
-
-    // Calcul du nombre de charges
+    // Calculate number of charges
     // Poisons :
     if (m_spellInfo->SpellFamilyName == SPELLFAMILY_ROGUE)
         charges = GetPoisonCharges(m_spellInfo->Id);
@@ -3849,7 +3812,7 @@ void Spell::EffectEnchantItemTmp(SpellEffectIndex eff_idx)
     // remove old enchant before applying new
     item_owner->ApplyEnchantment(itemTarget, TEMP_ENCHANTMENT_SLOT, false);
 
-    itemTarget->SetEnchantment(TEMP_ENCHANTMENT_SLOT, enchant_id, duration * 1000, charges);
+    itemTarget->SetEnchantment(TEMP_ENCHANTMENT_SLOT, enchant_id, damage * 1000, charges);
 
     // add new enchanting if equipped
     item_owner->ApplyEnchantment(itemTarget, TEMP_ENCHANTMENT_SLOT, true);


### PR DESCRIPTION
Fixes https://github.com/LightsHope/issues/issues/107

Removes all the hardcoded rules and fixes the enchant durations through the DB instead.