### PR TITLE
Logout fixes.

### DIFF
--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -746,6 +746,8 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder *holder)
         if (Group* pGroup = pCurrChar->GetGroup())
             pGroup->SendLootStartRollsForPlayer(pCurrChar);
 
+    GetPlayer()->RemoveAurasDueToSpell(SPELL_LOGOUT_STUN_SELF);
+
     // Update warden speeds
     //if (GetWarden())
         //for (int i = 0; i < MAX_MOVE_TYPE; ++i)

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -313,7 +313,7 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPacket & /*recv_data*/)
     if (GetPlayer()->isInCombat())
         reason = 1;
     else if (GetPlayer()->m_movementInfo.HasMovementFlag(MovementFlags(MOVEFLAG_JUMPING | MOVEFLAG_FALLINGFAR))
-        || !GetPlayer()->CanFreeMove())
+        || GetPlayer()->hasUnitState(UNIT_STAT_CAN_NOT_REACT))
         reason = 3;                                         // is jumping or falling or is controlled anyhow
     else if (GetPlayer()->duel || GetPlayer()->HasAura(9454)) // is dueling or frozen by GM via freeze command
         reason = 2;                                         // FIXME - Need the correct value

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -362,6 +362,10 @@ void WorldSession::HandleLogoutCancelOpcode(WorldPacket & /*recv_data*/)
 {
     DEBUG_LOG("WORLD: Recvd CMSG_LOGOUT_CANCEL Message");
 
+    // 1.12.1 sends it twice
+    if (!isLogingOut())
+        return;
+
     LogoutRequest(0);
 
     WorldPacket data(SMSG_LOGOUT_CANCEL_ACK, 0);

--- a/src/game/Handlers/MiscHandler.cpp
+++ b/src/game/Handlers/MiscHandler.cpp
@@ -340,12 +340,11 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPacket & /*recv_data*/)
         return;
     }
 
+    GetPlayer()->AddAura(SPELL_LOGOUT_STUN_SELF);
+
     float height = GetPlayer()->GetMap()->GetHeight(GetPlayer()->GetPositionX(), GetPlayer()->GetPositionY(), GetPlayer()->GetPositionZ());
     if ((GetPlayer()->GetPositionZ() < height + 0.1f) && !(GetPlayer()->IsInWater()) && GetPlayer()->getStandState() == UNIT_STAND_STATE_STAND)
         GetPlayer()->SetStandState(UNIT_STAND_STATE_SIT);
-
-    GetPlayer()->SetMovement(MOVE_ROOT);
-    GetPlayer()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_STUNNED);
 
     WorldPacket data(SMSG_LOGOUT_RESPONSE, 1 + 4);
     data << uint32(0);
@@ -368,18 +367,11 @@ void WorldSession::HandleLogoutCancelOpcode(WorldPacket & /*recv_data*/)
     WorldPacket data(SMSG_LOGOUT_CANCEL_ACK, 0);
     SendPacket(&data);
 
-    // not remove flags if can't free move - its not set in Logout request code.
+    GetPlayer()->RemoveAurasDueToSpell(SPELL_LOGOUT_STUN_SELF);
+
+    // Stand Up
     if (GetPlayer()->CanFreeMove())
-    {
-        //!we can move again
-        GetPlayer()->SetMovement(MOVE_UNROOT);
-
-        //! Stand Up
         GetPlayer()->SetStandState(UNIT_STAND_STATE_STAND);
-
-        //! DISABLE_ROTATE
-        GetPlayer()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_STUNNED);
-    }
 
     DEBUG_LOG("WORLD: sent SMSG_LOGOUT_CANCEL_ACK Message");
 }

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -5062,9 +5062,15 @@ void Spell::RemoveChanneledAuraHolder(SpellAuraHolder *holder, AuraRemoveMode mo
 
 SpellCastResult Spell::CheckCast(bool strict)
 {
-    // Cheat du joueur ?
-    if (m_caster->IsPlayer() && m_caster->ToPlayer()->HasOption(PLAYER_CHEAT_NO_CHECK_CAST))
-        return SPELL_CAST_OK;
+    if (Player *player = m_caster->ToPlayer())
+    {
+        // Player cheat ?
+        if (player->HasOption(PLAYER_CHEAT_NO_CHECK_CAST))
+            return SPELL_CAST_OK;
+        // Logging out ?
+        if (player->GetSession()->isLogingOut())
+            return SPELL_FAILED_STUNNED;
+    }
 
     //sLog.outString("CheckCast de %u %s%s%s sur %s",
     //   m_spellInfo->Id, strict ? "[strict]" : "", m_IsTriggeredSpell ? "[triggered]" : "", m_triggeredByAuraSpell ? "[triggeredByAura]" : "", m_targets.getUnitTargetGuid().GetString().c_str());

--- a/src/game/WorldSession.h
+++ b/src/game/WorldSession.h
@@ -204,6 +204,8 @@ enum AccountFlags
     ACCOUNT_FLAG_MUTED_FROM_PUBLIC_CHANNELS     = 0x1,
 };
 
+const uint32 SPELL_LOGOUT_STUN_SELF = 25900;
+
 //class to deal with packet processing
 //allows to determine if next packet is safe to be processed
 class PacketFilter


### PR DESCRIPTION
* refuse the logout when a player is stunned, feigning death, confused or fleeing
* during logout set an unused no-slot aura 25900 "stun self" to prevent the stun effect being removed by another aura fading
* prevent any cast during logout to avoid a mage ice block-ing out of stun