### PR TITLE
DM West pylon creature range

### DIFF
--- a/src/scripts/kalimdor/feralas/dire_maul/instance_dire_maul.cpp
+++ b/src/scripts/kalimdor/feralas/dire_maul/instance_dire_maul.cpp
@@ -554,7 +554,7 @@ void instance_dire_maul::DoSortCristalsEventMobs()
             {
                 if (Creature* pCreature = instance->GetCreature(*itr))
                 {
-                    if (pCreature->isAlive() && pCreature->GetDistance(pRune) < 10.0f)
+                    if (pCreature->isAlive() && pCreature->GetDistance(pRune) < 20.0f)
                         m_alCristalsEventtMobGUIDSorted[i].push_back(*itr);
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/LightsHope/issues/issues/168

10 yard range was too short for the mobs around the pylons.