### PR TITLE
NPC low health speed reductions

### DIFF
--- a/src/game/Movement/HomeMovementGenerator.cpp
+++ b/src/game/Movement/HomeMovementGenerator.cpp
@@ -38,6 +38,8 @@ void HomeMovementGenerator<Creature>::_setTargetLocation(Creature & owner)
     if (owner.hasUnitState(UNIT_STAT_CAN_NOT_MOVE))
         return;
 
+    owner.SetInjuredSpeedReduction(SPEED_REDUCTION_NONE);
+
     Movement::MoveSplineInit init(owner, "HomeMovementGenerator");
     float x, y, z, o;
     // at apply we can select more nice return points base at current movegen

--- a/src/game/Movement/HomeMovementGenerator.cpp
+++ b/src/game/Movement/HomeMovementGenerator.cpp
@@ -38,7 +38,10 @@ void HomeMovementGenerator<Creature>::_setTargetLocation(Creature & owner)
     if (owner.hasUnitState(UNIT_STAT_CAN_NOT_MOVE))
         return;
 
-    owner.SetInjuredSpeedReduction(SPEED_REDUCTION_NONE);
+    // Remove speed reductions from low hp
+    owner.ModifyAuraState(AURA_STATE_HEALTHLESS_15_PERCENT, false);
+    owner.ModifyAuraState(AURA_STATE_HEALTHLESS_10_PERCENT, false);
+    owner.ModifyAuraState(AURA_STATE_HEALTHLESS_5_PERCENT, false);
 
     Movement::MoveSplineInit init(owner, "HomeMovementGenerator");
     float x, y, z, o;

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -971,7 +971,7 @@ void Creature::DoFleeToGetAssistance()
 float Creature::GetFleeingSpeed() const
 {
     //TODO: There are different speeds for the different mobs, isn't there?
-    return GetSpeed(MOVE_RUN) * 0.6f;
+    return GetSpeed(MOVE_RUN);
 }
 
 bool Creature::AIM_Initialize()
@@ -1823,6 +1823,7 @@ void Creature::SetDeathState(DeathState s)
 
         SetHealth(GetMaxHealth());
         SetLootRecipient(nullptr);
+        SetInjuredSpeedReduction(SPEED_REDUCTION_NONE);
 
         if (GetTemporaryFactionFlags() & TEMPFACTION_RESTORE_RESPAWN)
             ClearTemporaryFaction();
@@ -3675,4 +3676,29 @@ void Creature::DespawnOrUnsummon(uint32 msTimeToDespawn /*= 0*/)
         static_cast<Pet*>(this)->DelayedUnsummon(msTimeToDespawn, PET_SAVE_AS_DELETED);
     else
         ForcedDespawn(msTimeToDespawn);
+}
+
+void Creature::UpdateInjuredSpeedReduction()
+{
+    if (IsPet() || IsWorldBoss())
+        return;
+
+    uint32 perc = (GetHealth() * 100) / GetMaxHealth();
+    if (perc > 15)
+        SetInjuredSpeedReduction(SPEED_REDUCTION_NONE);
+    else if (perc > 10)
+        SetInjuredSpeedReduction(SPEED_REDUCTION_HP_15);
+    else if (perc > 5)
+        SetInjuredSpeedReduction(SPEED_REDUCTION_HP_10);
+    else
+        SetInjuredSpeedReduction(SPEED_REDUCTION_HP_5);
+}
+
+void Creature::SetInjuredSpeedReduction(float reduction)
+{
+    if (m_injuredSpeedReduction == reduction)
+        return;
+
+    m_injuredSpeedReduction = reduction;
+    UpdateSpeed(MOVE_RUN, true);
 }

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -177,7 +177,7 @@ Creature::Creature(CreatureSubtype subtype) :
     m_combatStartX(0.0f), m_combatStartY(0.0f), m_combatStartZ(0.0f),
     m_HomeX(0.0f), m_HomeY(0.0f), m_HomeZ(0.0f), m_HomeOrientation(0.0f), m_reactState(REACT_PASSIVE),
     m_CombatDistance(0.0f), _lastDamageTakenForEvade(0), _playerDamageTaken(0), _nonPlayerDamageTaken(0), m_creatureInfo(nullptr),
-    m_AI_InitializeOnRespawn(false), m_callForHelpDist(5.0f), m_combatWithZoneState(false)
+    m_AI_InitializeOnRespawn(false), m_callForHelpDist(5.0f), m_combatWithZoneState(false), m_injuredSpeedReduction(1.0f)
 {
     m_regenTimer = 200;
     m_valuesCount = UNIT_END;

--- a/src/game/Objects/Creature.h
+++ b/src/game/Objects/Creature.h
@@ -64,7 +64,6 @@ enum CreatureFlagsExtra
     CREATURE_FLAG_EXTRA_KEEP_POSITIVE_AURAS_ON_EVADE = 0x00001000,       // creature keeps positive auras at reset
     CREATURE_FLAG_EXTRA_ALWAYS_CRUSH                 = 0x00002000,       // creature always roll a crushing melee outcome when not miss/crit/dodge/parry/block
     CREATURE_FLAG_EXTRA_IMMUNE_AOE                   = 0x00004000,       // creature is immune to AoE
-    CREATURE_FLAG_EXTRA_NO_INJURED_SPEED             = 0x00008000,       // creature is not affected by speed reductions at low health
 };
 
 // GCC have alternative #pragma pack(N) syntax and old gcc version not support pack(push,N), also any gcc version not support it at some platform
@@ -842,20 +841,11 @@ class MANGOS_DLL_SPEC Creature : public Unit
             m_callForHelpDist = dist;
         }
 
+        void UpdateInjuredSpeedReduction();
+        void SetInjuredSpeedReduction(float reduction);
         float GetInjuredSpeedReduction() const
         {
             return m_injuredSpeedReduction;
-        }
-
-        void SetInjuredSpeedReduction(float reduction)
-        {
-            if (m_injuredSpeedReduction == reduction)
-                return;
-
-            m_injuredSpeedReduction = reduction;
-            UpdateSpeed(MOVE_RUN, true);
-            UpdateSpeed(MOVE_WALK, true);
-            UpdateSpeed(MOVE_SWIM, true);
         }
 
         // (msecs)timer used for group loot

--- a/src/game/Objects/Creature.h
+++ b/src/game/Objects/Creature.h
@@ -841,13 +841,6 @@ class MANGOS_DLL_SPEC Creature : public Unit
             m_callForHelpDist = dist;
         }
 
-        void UpdateInjuredSpeedReduction();
-        void SetInjuredSpeedReduction(float reduction);
-        float GetInjuredSpeedReduction() const
-        {
-            return m_injuredSpeedReduction;
-        }
-
         // (msecs)timer used for group loot
         uint32 GetGroupLootTimer() { return m_groupLootTimer; }
 
@@ -924,7 +917,6 @@ class MANGOS_DLL_SPEC Creature : public Unit
         uint32 _nonPlayerDamageTaken;
         
         float m_callForHelpDist;
-        float m_injuredSpeedReduction;
 
     private:
         GridReference<Creature> m_gridRef;

--- a/src/game/Objects/Creature.h
+++ b/src/game/Objects/Creature.h
@@ -64,6 +64,7 @@ enum CreatureFlagsExtra
     CREATURE_FLAG_EXTRA_KEEP_POSITIVE_AURAS_ON_EVADE = 0x00001000,       // creature keeps positive auras at reset
     CREATURE_FLAG_EXTRA_ALWAYS_CRUSH                 = 0x00002000,       // creature always roll a crushing melee outcome when not miss/crit/dodge/parry/block
     CREATURE_FLAG_EXTRA_IMMUNE_AOE                   = 0x00004000,       // creature is immune to AoE
+    CREATURE_FLAG_EXTRA_NO_INJURED_SPEED             = 0x00008000,       // creature is not affected by speed reductions at low health
 };
 
 // GCC have alternative #pragma pack(N) syntax and old gcc version not support pack(push,N), also any gcc version not support it at some platform
@@ -76,6 +77,11 @@ enum CreatureFlagsExtra
 #define MAX_KILL_CREDIT 2
 #define MAX_CREATURE_MODEL 4                                // only single send to client in static data
 #define CREATURE_FLEE_TEXT 1150
+
+#define SPEED_REDUCTION_NONE   1.0f
+#define SPEED_REDUCTION_HP_15  0.7f
+#define SPEED_REDUCTION_HP_10  0.6f
+#define SPEED_REDUCTION_HP_5   0.5f
 
 // from `creature_template` table
 struct CreatureInfo
@@ -836,6 +842,22 @@ class MANGOS_DLL_SPEC Creature : public Unit
             m_callForHelpDist = dist;
         }
 
+        float GetInjuredSpeedReduction() const
+        {
+            return m_injuredSpeedReduction;
+        }
+
+        void SetInjuredSpeedReduction(float reduction)
+        {
+            if (m_injuredSpeedReduction == reduction)
+                return;
+
+            m_injuredSpeedReduction = reduction;
+            UpdateSpeed(MOVE_RUN, true);
+            UpdateSpeed(MOVE_WALK, true);
+            UpdateSpeed(MOVE_SWIM, true);
+        }
+
         // (msecs)timer used for group loot
         uint32 GetGroupLootTimer() { return m_groupLootTimer; }
 
@@ -912,6 +934,7 @@ class MANGOS_DLL_SPEC Creature : public Unit
         uint32 _nonPlayerDamageTaken;
         
         float m_callForHelpDist;
+        float m_injuredSpeedReduction;
 
     private:
         GridReference<Creature> m_gridRef;

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -7561,22 +7561,9 @@ int32 Unit::ModifyHealth(int32 dVal)
         gain = maxHealth - curHealth;
     }
 
+    // Apply speed reduction at low health percentages
     if (Creature *creature = ToCreature())
-    {
-        // Apply speed reduction at low health percentages
-        if (!(creature->GetCreatureInfo()->flags_extra & CREATURE_FLAG_EXTRA_NO_INJURED_SPEED))
-        {
-            float hpPercent = GetHealthPercent();
-            if (hpPercent > 15.0f)
-                creature->SetInjuredSpeedReduction(SPEED_REDUCTION_NONE);
-            else if (hpPercent > 10.0f)
-                creature->SetInjuredSpeedReduction(SPEED_REDUCTION_HP_15);
-            else if (hpPercent > 5.0f)
-                creature->SetInjuredSpeedReduction(SPEED_REDUCTION_HP_10);
-            else
-                creature->SetInjuredSpeedReduction(SPEED_REDUCTION_HP_5);
-        }
-    }
+        creature->UpdateInjuredSpeedReduction();
 
     return gain;
 }

--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -781,7 +781,11 @@ enum AuraState
     AURA_STATE_JUDGEMENT                    = 5,            // C   |
     //AURA_STATE_UNKNOWN6                   = 6,            //     | not used
     AURA_STATE_HUNTER_PARRY                 = 7,            // C   |
-    AURA_STATE_ROGUE_ATTACK_FROM_STEALTH    = 7,            // C   | FIX ME: not implemented yet!
+    AURA_STATE_ROGUE_ATTACK_FROM_STEALTH    = 8,            // C   | FIX ME: not implemented yet!
+    // Custom aura states - not based on spell data:
+    AURA_STATE_HEALTHLESS_15_PERCENT        = 9,
+    AURA_STATE_HEALTHLESS_10_PERCENT        = 10,
+    AURA_STATE_HEALTHLESS_5_PERCENT         = 11,
 };
 
 // Spell mechanics


### PR DESCRIPTION
Issue https://github.com/LightsHope/issues/issues/178

Implemented the speed reductions on all mobs except pets and worldboss rank creatures.
There already was a speed reduction on low hp fleeing mobs that I assume is a misinterpretation of this mechanic so I removed that.

Unsure of what is the best time to call _UpdateInjuredSpeedReduction()_. On ModifyHealth, just on DealDamage or maybe on the creatures Update tick?