### PR TITLE
Fix to C'thun stomach death

### DIFF
--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/instance_temple_of_ahnqiraj.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/instance_temple_of_ahnqiraj.cpp
@@ -652,7 +652,7 @@ bool instance_temple_of_ahnqiraj::KillPlayersInStomach()
             }
 
             if (p->isAlive()) {
-                p->KillPlayer();
+                p->DealDamage(p, p->GetHealth(), nullptr, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, nullptr, false);
             }
             if (p->HasAura(SPELL_DIGESTIVE_ACID)) {
                 p->RemoveAurasDueToSpell(SPELL_DIGESTIVE_ACID);


### PR DESCRIPTION
Fixes the players bugged death state if people are left alive in the stomach after a wipe.