### PR TITLE
Fix to aura update masks

### DIFF
--- a/src/game/Handlers/GroupHandler.cpp
+++ b/src/game/Handlers/GroupHandler.cpp
@@ -669,7 +669,7 @@ void WorldSession::BuildPartyMemberStatsPacket(Player* player, WorldPacket* data
 
     if (mask & GROUP_UPDATE_FLAG_AURAS_NEGATIVE)
     {
-        uint64 auramask = sendAllAuras ? player->GetAuraApplicationMask() : player->GetAuraUpdateMask();
+        uint64 auramask = sendAllAuras ? player->GetNegativeAuraApplicationMask() : player->GetAuraUpdateMask();
         uint16 maskForClient = uint16(auramask >> 32);
         *data << maskForClient;
         for (uint64 i = MAX_POSITIVE_AURAS; i < MAX_AURAS; ++i)
@@ -757,7 +757,7 @@ void WorldSession::BuildPartyMemberStatsPacket(Player* player, WorldPacket* data
     {
         if (pet)
         {
-            uint64 auramask = sendAllAuras ? pet->GetAuraApplicationMask() : pet->GetAuraUpdateMask();
+            uint64 auramask = sendAllAuras ? pet->GetNegativeAuraApplicationMask() : pet->GetAuraUpdateMask();
             *data << uint16(auramask >> 32);
             for (uint32 i = MAX_POSITIVE_AURAS; i < MAX_AURAS; ++i)
             {

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -495,6 +495,18 @@ uint64 Unit::GetAuraApplicationMask() const
         return 0;
 
     uint64 mask = 0x0;
+    for (uint64 i = 0; i < MAX_AURAS; ++i)
+        if (GetUInt32Value(UNIT_FIELD_AURA + i))
+            mask |= uint64(1) << i;
+    return mask;
+}
+
+uint64 Unit::GetNegativeAuraApplicationMask() const
+{
+    if (!IsInWorld())
+        return 0;
+
+    uint64 mask = 0x0;
     for (uint64 i = MAX_POSITIVE_AURAS; i < MAX_AURAS; ++i)
         if (GetUInt32Value(UNIT_FIELD_AURA + i))
             mask |= uint64(1) << i;

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -1260,6 +1260,7 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         uint32 GetFirstAuraBySpellIconAndVisual(uint32 spellIconId, uint32 spellVisual) const;
 
         uint64 GetAuraApplicationMask() const;
+        uint64 GetNegativeAuraApplicationMask() const;
 
         SpellAuraHolderBounds GetSpellAuraHolderBounds(uint32 spell_id)
         {


### PR DESCRIPTION
Fixes https://github.com/LightsHope/issues/issues/175

_GetAuraApplicationMask_ was checking only negative auras. Changed it to check all auras instead and created a _GetNegativeAuraApplicationMask_ to be used on negative aura only updates.