### PR TITLE
Refactor encounter in progress check

### DIFF
--- a/sql/migrations/20180408015542_world.sql
+++ b/sql/migrations/20180408015542_world.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180408015542');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180408015542');
+-- Add your query below.
+
+UPDATE `map_template` SET `ScriptName`='instance_onyxia_lair' WHERE `Entry`=249;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Group/Group.cpp
+++ b/src/game/Group/Group.cpp
@@ -1915,7 +1915,7 @@ bool Group::InCombatToInstance(uint32 instanceId)
     for (GroupReference *itr = GetFirstMember(); itr != NULL; itr = itr->next())
     {
         Player *pPlayer = itr->getSource();
-        if (pPlayer->getAttackers().size() && pPlayer->GetInstanceId() == instanceId)
+        if (pPlayer->isInCombat() && pPlayer->GetInstanceId() == instanceId)
             return true;
     }
     return false;

--- a/src/game/Handlers/CharacterHandler.cpp
+++ b/src/game/Handlers/CharacterHandler.cpp
@@ -619,6 +619,8 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder *holder)
         AreaTrigger const* at = sObjectMgr.GetGoBackTrigger(pCurrChar->GetMapId());
         if (at)
             pCurrChar->TeleportTo(at->target_mapId, at->target_X, at->target_Y, at->target_Z, pCurrChar->GetOrientation());
+        else if (pCurrChar->GetMapId() == 533)
+            pCurrChar->TeleportTo(0, 3120.16f, -3724.93f, 137.66f, 5.83567f); // Naxxramas has no exit trigger
         else
             pCurrChar->TeleportToHomebind();
 

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -1814,16 +1814,14 @@ bool DungeonMap::CanEnter(Player *player)
         return false;
     }
 
-    // cannot enter while players in the instance are in combat
+    // cannot enter while an encounter is in progress
     Group *pGroup = player->GetGroup();
-    if (pGroup && pGroup->InCombatToInstance(GetInstanceId()) && player->isAlive() && player->GetMapId() != GetId())
+    if (IsRaid() && GetInstanceData() && GetInstanceData()->IsEncounterInProgress() && 
+        pGroup && pGroup->InCombatToInstance(GetInstanceId()) && player->isAlive() && 
+        player->GetMapId() != GetId() && !player->isGameMaster())
     {
-        
-        if (GetId() == 249 || GetId() == 531 || GetId() == 533)        // Hack : Ustaag <Nostalrius> : concerne uniquement Onyxia's Lair
-        {
-            player->SendTransferAborted(TRANSFER_ABORT_ZONE_IN_COMBAT);
-            return false;
-        }
+        player->SendTransferAborted(TRANSFER_ABORT_ZONE_IN_COMBAT);
+        return false;
     }
 
     if (GetId() == 509 || GetId() == 531)
@@ -1834,7 +1832,6 @@ bool DungeonMap::CanEnter(Player *player)
             return false;
         }
     }
-
 
     return Map::CanEnter(player);
 }

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -1817,8 +1817,7 @@ bool DungeonMap::CanEnter(Player *player)
     // cannot enter while an encounter is in progress
     Group *pGroup = player->GetGroup();
     if (IsRaid() && GetInstanceData() && GetInstanceData()->IsEncounterInProgress() && 
-        pGroup && pGroup->InCombatToInstance(GetInstanceId()) && player->isAlive() && 
-        player->GetMapId() != GetId() && !player->isGameMaster())
+        pGroup && pGroup->InCombatToInstance(GetInstanceId()) && player->isAlive() && !player->isGameMaster())
     {
         player->SendTransferAborted(TRANSFER_ABORT_ZONE_IN_COMBAT);
         return false;

--- a/src/game/Maps/MapManager.cpp
+++ b/src/game/Maps/MapManager.cpp
@@ -208,14 +208,6 @@ bool MapManager::CanPlayerEnter(uint32 mapid, Player* player)
             player->SendTransferAborted(TRANSFER_ABORT_TOO_MANY_INSTANCES);
             return false;
         }
-
-        // TODO: move this to a map dependent location
-        /*if(i_data && i_data->IsEncounterInProgress())
-        {
-            DEBUG_LOG("MAP: Player '%s' can't enter instance '%s' while an encounter is in progress.", player->GetName(), GetMapName());
-            player->SendTransferAborted(TRANSFER_ABORT_ZONE_IN_COMBAT);
-            return(false);
-        }*/
     }
 
     return true;

--- a/src/scripts/ScriptLoader.cpp
+++ b/src/scripts/ScriptLoader.cpp
@@ -220,6 +220,7 @@ void AddSC_boss_noxxion();
 void AddSC_boss_ptheradras();
 void AddSC_maraudon();
 void AddSC_instance_maraudon();
+void AddSC_instance_onyxia_lair();
 void AddSC_boss_onyxia();                            //onyxias_lair
 void AddSC_boss_amnennar_the_coldbringer();          //razorfen_downs
 void AddSC_razorfen_downs();
@@ -493,6 +494,7 @@ void AddScripts()
     AddSC_boss_ptheradras();
     AddSC_maraudon();
     AddSC_instance_maraudon();
+    AddSC_instance_onyxia_lair();
     AddSC_boss_onyxia();                                    //onyxias_lair
     AddSC_boss_amnennar_the_coldbringer();                  //razorfen_downs
     AddSC_razorfen_downs();

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_flamegor.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/boss_flamegor.cpp
@@ -50,11 +50,6 @@ struct boss_flamegorAI : public ScriptedAI
     uint32 m_uiWingBuffetTimer;
     uint32 m_uiFrenzyTimer;
 
-    void EnterCombat(Unit* /*pWho*/)
-    {
-        m_creature->SetInCombatWithZone();
-    }
-
     void Reset()
     {
         m_uiShadowFlameTimer = 16000;                        // These times are probably wrong

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/instance_blackwing_lair.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/instance_blackwing_lair.cpp
@@ -123,7 +123,7 @@ enum
     MOB_DRACO_VERT              = 14023,
     MOB_DRACO_ROUGE             = 14022,
     MOB_DRACO_BLEU              = 14024,
-    MOB_DRACO_BRONZE            = 14025,
+    MOB_DRACO_BRONZE            = 14025,g
     GO_SUPPRESSION_ENGINE       = 179784,
     // Drags
     MOB_DEMONISTE_AILE_NOIRE    = 12459,
@@ -273,6 +273,8 @@ struct instance_blackwing_lair : public ScriptedInstance
 
     bool IsEncounterInProgress() const
     {
+        // Don't include TYPE_SCEPTER_RUN status in encounter progress check
+        // TODO: Move scepter run out of encounter ordering
         for (int i = 0; i < TYPE_VAEL_EVENT; i++)
         {
             if (m_auiEncounter[i] == IN_PROGRESS)

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/instance_blackwing_lair.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/instance_blackwing_lair.cpp
@@ -273,7 +273,7 @@ struct instance_blackwing_lair : public ScriptedInstance
 
     bool IsEncounterInProgress() const
     {
-        for (int i = 0; i < MAX_ENCOUNTER; i++)
+        for (int i = 0; i < TYPE_VAEL_EVENT; i++)
         {
             if (m_auiEncounter[i] == IN_PROGRESS)
                 return true;

--- a/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/instance_blackwing_lair.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/blackwing_lair/instance_blackwing_lair.cpp
@@ -123,7 +123,7 @@ enum
     MOB_DRACO_VERT              = 14023,
     MOB_DRACO_ROUGE             = 14022,
     MOB_DRACO_BLEU              = 14024,
-    MOB_DRACO_BRONZE            = 14025,g
+    MOB_DRACO_BRONZE            = 14025,
     GO_SUPPRESSION_ENGINE       = 179784,
     // Drags
     MOB_DEMONISTE_AILE_NOIRE    = 12459,

--- a/src/scripts/eastern_kingdoms/burning_steppes/molten_core/instance_molten_core.cpp
+++ b/src/scripts/eastern_kingdoms/burning_steppes/molten_core/instance_molten_core.cpp
@@ -92,6 +92,10 @@ struct instance_molten_core : ScriptedInstance
 
     bool IsEncounterInProgress() const override
     {
+        for (uint8 i = 0; i < INSTANCE_MC_MAX_ENCOUNTER; ++i)
+            if (m_auiEncounter[i] == IN_PROGRESS || m_auiEncounter[i] == SPECIAL)
+                return true;
+
         return false;
     }
 

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_sapphiron.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_sapphiron.cpp
@@ -159,6 +159,9 @@ struct boss_sapphironAI : public ScriptedAI
         setHover(false, true);
         SetCombatMovement(true);
         m_TargetNotReachableTimer = 0;
+
+        if (m_pInstance && m_pInstance->GetData(TYPE_SAPPHIRON) != DONE)
+            m_pInstance->SetData(TYPE_SAPPHIRON, NOT_STARTED);
     }
 
     void UnSummonWingBuffet()

--- a/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_gahzranka.cpp
+++ b/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_gahzranka.cpp
@@ -61,6 +61,19 @@ struct boss_gahzrankaAI : public ScriptedAI
         Frostbreath_Timer = 8000;
         MassiveGeyser_Timer = 25000;
         Slam_Timer = 17000;
+
+        if (m_pInstance && m_pInstance->GetData(TYPE_GAHZRANKA) != DONE)
+            m_pInstance->SetData(TYPE_GAHZRANKA, NOT_STARTED);
+    }
+    void Aggro(Unit *who)
+    {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_GAHZRANKA, IN_PROGRESS);
+    }
+    void JustDied(Unit* Killer)
+    {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_GAHZRANKA, DONE);
     }
 
     void JustRespawned()
@@ -73,7 +86,7 @@ struct boss_gahzrankaAI : public ScriptedAI
         if (!m_pInstance)
             return;
 
-        if (m_pInstance->GetData(TYPE_GAHZRANKA) != DONE)
+        if (m_pInstance->GetData(TYPE_GAHZRANKA) != IN_PROGRESS)
         {
             m_creature->DisappearAndDie();
             m_creature->SetRespawnTime(259200);

--- a/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_hakkar.cpp
+++ b/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_hakkar.cpp
@@ -115,6 +115,22 @@ struct boss_hakkarAI : public ScriptedAI
         AspectOfArlokk_Timer = 18000;
 
         Enraged = false;
+
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_HAKKAR, NOT_STARTED);
+    }
+
+    void Aggro(Unit *who)
+    {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_HAKKAR, IN_PROGRESS);
+        ScriptedAI::Aggro(who);
+    }
+
+    void JustDied(Unit* Killer)
+    {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_HAKKAR, DONE);
     }
 
     void UpdateAI(const uint32 diff)

--- a/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_jindo.cpp
+++ b/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_jindo.cpp
@@ -119,6 +119,9 @@ struct boss_jindoAI : public ScriptedAI
         BrainWashedPlayerAggro.clear();
 
         DespawnAllSummons();
+
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_JINDO, NOT_STARTED);
     }
 
     void SpellHitTarget(Unit* pCaster, const SpellEntry* pSpell)
@@ -138,11 +141,15 @@ struct boss_jindoAI : public ScriptedAI
     void JustDied(Unit* pKiller)
     {
         DespawnAllSummons();
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_JINDO, DONE);
     }
 
     void Aggro(Unit *who)
     {
         DoScriptText(SAY_AGGRO, m_creature);
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_JINDO, IN_PROGRESS);
     }
 
     void DoSummonSkeleton(float addx, float addy, Unit* initialTarget)

--- a/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_thekal.cpp
+++ b/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_thekal.cpp
@@ -121,6 +121,12 @@ struct zg_rez_add : public ScriptedAI
     {
         return _realyDead;
     }
+    void Aggro(Unit *who)
+    {
+        if (m_pInstance)
+            m_pInstance->SetData(m_uiInstMobType, IN_PROGRESS);
+        ScriptedAI::Aggro(who);
+    }
 
     void JustDied(Unit* Killer)
     {
@@ -130,7 +136,6 @@ struct zg_rez_add : public ScriptedAI
         m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
         if (m_pInstance)
         {
-            m_pInstance->SetData(m_uiInstMobType, SPECIAL);
             pRezzer = m_pInstance->Thekal_GetUnitThatCanRez();
         }
         if (pRezzer)
@@ -213,6 +218,8 @@ struct zg_rez_add : public ScriptedAI
     }
     void Reset()
     {
+        if (m_pInstance)
+            m_pInstance->SetData(m_uiInstMobType, NOT_STARTED);
     }
 
     uint32 m_uiInstMobType;
@@ -299,11 +306,6 @@ struct boss_thekalAI : public zg_rez_add
 
         Enraged = false;
 
-        if (m_pInstance)
-        {
-            m_pInstance->SetData(TYPE_LORKHAN, SPECIAL);
-            m_pInstance->SetData(TYPE_ZATH, SPECIAL);
-        }
         // Si en phase 2 avant de reset, faut repop les 2 adds.
         m_creature->RespawnNearCreaturesByEntry(ZELOTH_LOR_KHAN, 100.0f);
         m_creature->RespawnNearCreaturesByEntry(ZELOTH_ZATH, 100.0f);
@@ -320,7 +322,11 @@ struct boss_thekalAI : public zg_rez_add
             DEBUG_UNIT(m_creature, DEBUG_AI, "Thekal is dead for real");
 
             if (m_pInstance)
+            {
+                m_pInstance->SetData(TYPE_LORKHAN, DONE);
+                m_pInstance->SetData(TYPE_ZATH, DONE);
                 m_pInstance->SetData(TYPE_THEKAL, DONE);
+            }
 
             ScriptedAI::JustDied(Killer);
         }
@@ -370,6 +376,8 @@ struct boss_thekalAI : public zg_rez_add
 
     void Aggro(Unit *who)
     {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_THEKAL, IN_PROGRESS);
         if (PhaseTwo)
             DoScriptText(SAY_AGGRO, m_creature);
         m_creature->SetInCombatWithZone();
@@ -392,12 +400,6 @@ struct boss_thekalAI : public zg_rez_add
         NoTargetReset_Timer = 5000;
         m_creature->DespawnNearCreaturesByEntry(ZELOTH_LOR_KHAN, 100.0f);
         m_creature->DespawnNearCreaturesByEntry(ZELOTH_ZATH, 100.0f);
-    }
-
-    void JustReachedHome()
-    {
-        if (m_pInstance)
-            m_pInstance->SetData(TYPE_THEKAL, NOT_STARTED);
     }
 
     void CheckTiger(uint64& guid)
@@ -552,9 +554,6 @@ struct mob_zealot_lorkhanAI : public zg_rez_add
         Resurrect_Timer = 10000;
         uiRezzeurGUID = 0;
 
-        if (m_pInstance)
-            m_pInstance->SetData(TYPE_LORKHAN, NOT_STARTED);
-
         m_creature->SetStandState(UNIT_STAND_STATE_STAND);
         m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
         zg_rez_add::Reset();
@@ -652,9 +651,6 @@ struct mob_zealot_zathAI : public zg_rez_add
 
         Resurrect_Timer = 10000;
         uiRezzeurGUID = 0;
-
-        if (m_pInstance)
-            m_pInstance->SetData(TYPE_ZATH, NOT_STARTED);
 
         m_creature->SetStandState(UNIT_STAND_STATE_STAND);
         m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);

--- a/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_venoxis.cpp
+++ b/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/boss_venoxis.cpp
@@ -117,6 +117,12 @@ struct boss_venoxisAI : public ScriptedAI
         }
     }
 
+    void Aggro(Unit* pWho)
+    {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_VENOXIS, IN_PROGRESS);
+    }
+
     void JustReachedHome()
     {
         std::list<Creature*> m_lCobras;
@@ -132,6 +138,9 @@ struct boss_venoxisAI : public ScriptedAI
                     (*iter)->Respawn();
             }
         }
+
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_VENOXIS, NOT_STARTED);
     }
 
     void JustDied(Unit* pKiller)

--- a/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/zulgurub.h
+++ b/src/scripts/eastern_kingdoms/stranglethorn_vale/zulgurub/zulgurub.h
@@ -7,7 +7,7 @@
 
 enum
 {
-    ZULGURUB_MAX_ENCOUNTER  = 11,
+    ZULGURUB_MAX_ENCOUNTER  = 13,
 
     NPC_LORKHAN             = 11347,
     NPC_ZATH                = 11348,
@@ -33,15 +33,15 @@ enum
     TYPE_LORKHAN            = 8,
     TYPE_HAKKAR             = 9,
     TYPE_RANDOM_BOSS        = 10,
+    TYPE_JINDO              = 11,
+    TYPE_GAHZRANKA          = 12,
 
-    DATA_JINDO              = 11,
-    DATA_LORKHAN            = 12,
-    DATA_THEKAL             = 13,
-    DATA_ZATH               = 14,
-    DATA_HAKKAR             = 15,
-
-    TYPE_GAHZRANKA          = 16,
-    DATA_GAHZRANKA          = 17
+    DATA_JINDO              = 13,
+    DATA_LORKHAN            = 14,
+    DATA_THEKAL             = 15,
+    DATA_ZATH               = 16,
+    DATA_HAKKAR             = 17,
+    DATA_GAHZRANKA          = 18
 };
 
 class instance_zulgurub : public ScriptedInstance
@@ -50,15 +50,15 @@ class instance_zulgurub : public ScriptedInstance
         instance_zulgurub(Map* pMap) : ScriptedInstance(pMap), m_randomBossSpawned(false) {Initialize();};
 
         void Initialize();
-                void Create();
+        void Create();
 
-        bool IsEncounterInProgress();
+        bool IsEncounterInProgress() const override;
         void OnCreatureCreate(Creature* pCreature);
-                void OnCreatureDeath(Creature * pCreature);
+        void OnCreatureDeath(Creature * pCreature);
         void SetData(uint32 uiType, uint32 uiData);
         const char* Save();
         void Load(const char* chrIn);
-                void HandleLoadCreature(uint32 dataType, uint64 &storeGuid, Creature* pCrea); // Nostalrius
+        void HandleLoadCreature(uint32 dataType, uint64 &storeGuid, Creature* pCrea); // Nostalrius
 
         uint32 GetData(uint32 uiType);
         uint64 GetData64(uint32 uiData);
@@ -71,8 +71,8 @@ class instance_zulgurub : public ScriptedInstance
 
     protected:
         std::string strInstData;
-                bool m_randomBossSpawned;
-                uint32 randomBossEntry;
+        bool m_randomBossSpawned;
+        uint32 randomBossEntry;
         // If all High Priest bosses were killed. Lorkhan, Zath and Ohgan are added too.
         uint32 m_auiEncounter[ZULGURUB_MAX_ENCOUNTER];
 
@@ -85,7 +85,7 @@ class instance_zulgurub : public ScriptedInstance
         uint64 m_uiGahzrankaGUID;
 
         uint64 m_uiMarliGUID;
-                std::list<uint64> m_lMarliTrashGUIDList;
+        std::list<uint64> m_lMarliTrashGUIDList;
 };
 
 #endif

--- a/src/scripts/kalimdor/dustwallow_marsh/onyxias_lair/instance_onyxia_lair.cpp
+++ b/src/scripts/kalimdor/dustwallow_marsh/onyxias_lair/instance_onyxia_lair.cpp
@@ -33,7 +33,7 @@ struct instance_onyxia_lair : public ScriptedInstance
 
     void SetData(uint32 uiType, uint32 uiData) override
     {
-        switch (identifier)
+        switch (uiType)
         {
             case DATA_ONYXIA_EVENT:
                 m_auiEncounter[0] = uiData;

--- a/src/scripts/kalimdor/dustwallow_marsh/onyxias_lair/instance_onyxia_lair.cpp
+++ b/src/scripts/kalimdor/dustwallow_marsh/onyxias_lair/instance_onyxia_lair.cpp
@@ -11,18 +11,7 @@ struct instance_onyxia_lair : public ScriptedInstance
     };
     uint32 m_auiEncounter[MAX_ENCOUNTER];
 
-    uint32 m_uiOnyxiaGUID;
-    uint32 m_uiOnyxiaDoorGUID;
-    uint32 m_uiOnyxiaEncounterDoorGUID;
-
-
-
-    void Initialize()
-    {
-        m_uiOnyxiaGUID = 0;
-        m_uiOnyxiaDoorGUID = 0;
-        m_uiOnyxiaEncounterDoorGUID = 0;
-    }
+    void Initialize() { }
 
     bool IsEncounterInProgress() const
     {
@@ -47,56 +36,9 @@ struct instance_onyxia_lair : public ScriptedInstance
         switch (identifier)
         {
             case DATA_ONYXIA_EVENT:
-                if (data == IN_PROGRESS)
-                {
-                    sLog.outString("Fermeture de l'instance pendant le combat contre Onyxia");
-                    if (m_uiOnyxiaDoorGUID)
-                        if (GameObject *pGo = instance->GetGameObject(m_uiOnyxiaDoorGUID))
-                            pGo->SetGoState(GO_STATE_READY);
-                }
-                if (data == NOT_STARTED)
-                {
-                    sLog.outString("Arrets des combats: ouverture de l'instance");
-                    if (m_uiOnyxiaDoorGUID)
-                        if (GameObject *pGo = instance->GetGameObject(m_uiOnyxiaDoorGUID))
-                            pGo->SetGoState(GO_STATE_ACTIVE);
-                }
                 m_auiEncounter[0] = data;
                 break;
         }
-    }
-
-    void OnCreatureCreate(Creature* pCreature)
-    {
-        switch (pCreature->GetEntry())
-        {
-            case 10184:
-                m_uiOnyxiaGUID = pCreature->GetGUID();
-                break;
-        }
-    }
-
-    void OnObjectCreate(GameObject* go)
-    {
-        switch (go->GetEntry())
-        {
-            case 177928:
-                m_uiOnyxiaDoorGUID = go->GetGUID();
-                break;
-        }
-    }
-    uint64 GetData64(uint32 identifier)
-    {
-        switch (identifier)
-        {
-            case DATA_ONYXIA:
-                return m_uiOnyxiaGUID;
-            case DATA_ONYXIA_DOOR:
-                return m_uiOnyxiaDoorGUID;
-            case DATA_ONYXIA_ENCOUNTER_DOOR:
-                return m_uiOnyxiaEncounterDoorGUID;
-        }
-        return 0;
     }
 };
 
@@ -114,13 +56,3 @@ void AddSC_instance_onyxia_lair()
     newscript->GetInstanceData = &GetInstanceData_instance_onyxia_lair;
     newscript->RegisterSelf();
 }
-
-
-
-
-
-
-
-
-
-

--- a/src/scripts/kalimdor/dustwallow_marsh/onyxias_lair/instance_onyxia_lair.cpp
+++ b/src/scripts/kalimdor/dustwallow_marsh/onyxias_lair/instance_onyxia_lair.cpp
@@ -31,12 +31,12 @@ struct instance_onyxia_lair : public ScriptedInstance
         return 0;
     }
 
-    void SetData(uint32 identifier, uint32 data)
+    void SetData(uint32 uiType, uint32 uiData) override
     {
         switch (identifier)
         {
             case DATA_ONYXIA_EVENT:
-                m_auiEncounter[0] = data;
+                m_auiEncounter[0] = uiData;
                 break;
         }
     }

--- a/src/scripts/kalimdor/dustwallow_marsh/onyxias_lair/instance_onyxia_lair.h
+++ b/src/scripts/kalimdor/dustwallow_marsh/onyxias_lair/instance_onyxia_lair.h
@@ -1,12 +1,6 @@
-#ifndef DEF_MAGISTERS_TERRACE_H
-#define DEF_MAGISTERS_TERRACE_H
+#ifndef DEF_ONYXIA_LAIR_H
+#define DEF_ONYXIA_LAIR_H
 
-#define DATA_ONYXIA_EVENT             1
+#define DATA_ONYXIA_EVENT             0
 
-#define DATA_ONYXIA                   2
-
-#define DATA_ONYXIA_DOOR              3
-#define DATA_ONYXIA_ENCOUNTER_DOOR    4
-
-#define ERROR_INST_DATA      "SD2 Error: Instance Data not set properly for Onyxia's Lair. Encounters will be buggy."
 #endif

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_ayamiss.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_ayamiss.cpp
@@ -72,8 +72,11 @@ struct boss_ayamissAI : public ScriptedAI
 {
     boss_ayamissAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
+        m_pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
         Reset();
     }
+
+    ScriptedInstance* m_pInstance;
 
     uint32 m_uiStingerSpray_Timer;
     uint32 m_uiPoisonStinger_Timer;
@@ -133,10 +136,21 @@ struct boss_ayamissAI : public ScriptedAI
             if ((*itr)->isAlive())
                 (*itr)->AddObjectToRemoveList();
         }
+
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_AYAMISS, NOT_STARTED);
     }
 
     void Aggro(Unit* pWho)
     {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_AYAMISS, IN_PROGRESS);
+    }
+
+    void JustDied(Unit* pKiller)
+    {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_AYAMISS, DONE);
     }
 
     void SpellHitTarget(Unit* pCaster, const SpellEntry* pSpell)

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_buru.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_buru.cpp
@@ -109,6 +109,9 @@ struct boss_buruAI : public ScriptedAI
             if (Creature* egg = m_creature->SummonCreature(NPC_BURU_EGG, Eggs[i].x, Eggs[i].y, Eggs[i].z, 0))
                 m_eggsGUID[i] = egg->GetGUID();
         }
+
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_BURU, NOT_STARTED);
     }
 
     void Aggro(Unit *pWho)
@@ -116,6 +119,8 @@ struct boss_buruAI : public ScriptedAI
         m_creature->SetInCombatWithZone();
         DoCast(m_creature, SPELL_THORNS);
         m_creature->SetArmor(20000);
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_BURU, IN_PROGRESS);
     }
 
     void JustDied(Unit* pKiller)
@@ -124,6 +129,9 @@ struct boss_buruAI : public ScriptedAI
         Map::PlayerList const &liste = m_creature->GetMap()->GetPlayers();
         for (Map::PlayerList::const_iterator i = liste.begin(); i != liste.end(); ++i)
             i->getSource()->RemoveAurasDueToSpell(SPELL_CREEPING_PLAGUE);
+
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_BURU, DONE);
     }
 
     void UpdateAI(const uint32 uiDiff)

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_moam.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_moam.cpp
@@ -22,6 +22,7 @@ SDCategory: Ruins of Ahn'Qiraj
 EndScriptData */
 
 #include "scriptPCH.h"
+#include "ruins_of_ahnqiraj.h"
 
 enum
 {
@@ -43,8 +44,11 @@ struct boss_moamAI : public ScriptedAI
 {
     boss_moamAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
+        m_pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
         Reset();
     }
+
+    ScriptedInstance* m_pInstance;
 
     uint32 m_uiTrample_Timer;
     uint32 m_uiSummonManaFiend_Timer;
@@ -72,6 +76,9 @@ struct boss_moamAI : public ScriptedAI
         m_uiArmorValue = m_creature->GetArmor();
 
         m_OGvictim.Clear();
+
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_MOAM, NOT_STARTED);
     }
 
     void Aggro(Unit* pWho)
@@ -83,6 +90,9 @@ struct boss_moamAI : public ScriptedAI
             m_creature->SetPower(POWER_MANA, 0);
             m_bIsInCombat = true;
         }
+
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_MOAM, IN_PROGRESS);
     }
 
     void JustDied(Unit* pKiller)
@@ -93,6 +103,9 @@ struct boss_moamAI : public ScriptedAI
                                 m_creature->GetPositionZ(),
                                 0, 0, 0, 0, 0, -1, false);
         pObsidian->SetRespawnTime(345600);
+
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_MOAM, DONE);
     }
 
     /** This function seems to be unused, kept as it is in case of...*/

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_ossirian.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_ossirian.cpp
@@ -202,6 +202,8 @@ struct boss_ossirianAI : public ScriptedAI
         uint32 zoneid = m_creature->GetZoneId();
         if (Weather* wth = sWorld.FindWeather(zoneid))
             wth->SetWeather(WeatherType(3), 2);
+
+        m_pInstance->SetData(TYPE_OSSIRIAN, IN_PROGRESS);
     }
 
     void JustDied(Unit* pKiller)

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/instance_ruins_of_ahnqiraj.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/instance_ruins_of_ahnqiraj.cpp
@@ -75,7 +75,7 @@ void instance_ruins_of_ahnqiraj::Initialize()
 bool instance_ruins_of_ahnqiraj::IsEncounterInProgress() const
 {
     for (uint8 i = 0; i < INSTANCE_RUINS_AQ_MAX_ENCOUNTER; ++i)
-        if (m_auiEncounter[i] == IN_PROGRESS)
+        if (m_auiEncounter[i] == IN_PROGRESS || m_auiEncounter[i] == SPECIAL)
             return true;
     return false;
 }
@@ -376,6 +376,10 @@ uint32 instance_ruins_of_ahnqiraj::GetData(uint32 uiType)
         case TYPE_KURINNAXX:
         case TYPE_GENERAL_ANDOROV:
         case TYPE_RAJAXX:
+        case TYPE_BURU:
+        case TYPE_MOAM:
+        case TYPE_AYAMISS:
+        case TYPE_OSSIRIAN:
             return m_auiEncounter[uiType];
         case TYPE_WAVE1:
         case TYPE_WAVE2:
@@ -468,6 +472,13 @@ void instance_ruins_of_ahnqiraj::SetData(uint32 uiType, uint32 uiData)
                 crystalIndexes.clear();
                 crystalIndexHistory.clear();
             }
+            m_auiEncounter[TYPE_OSSIRIAN] = uiData;
+            break;
+        case TYPE_BURU:
+        case TYPE_MOAM:
+        case TYPE_AYAMISS:
+            m_auiEncounter[uiType] = uiData;
+            break;
         default:
             return;
     }
@@ -478,7 +489,8 @@ void instance_ruins_of_ahnqiraj::SetData(uint32 uiType, uint32 uiData)
         OUT_SAVE_INST_DATA;
 
         std::ostringstream saveStream;
-        saveStream << m_auiEncounter[0] << " " << m_auiEncounter[1] << " " << m_auiEncounter[2] << " ";
+        saveStream << m_auiEncounter[0] << " " << m_auiEncounter[1] << " " << m_auiEncounter[2] << " "
+            << m_auiEncounter[3] << " " << m_auiEncounter[4] << " " << m_auiEncounter[5] << " " << m_auiEncounter[6];
 
         strInstData = saveStream.str();
 
@@ -504,7 +516,8 @@ void instance_ruins_of_ahnqiraj::Load(const char* chrIn)
 
     std::istringstream loadStream(chrIn);
 
-    loadStream    >> m_auiEncounter[0] >> m_auiEncounter[1] >> m_auiEncounter[2];
+    loadStream >> m_auiEncounter[0] >> m_auiEncounter[1] >> m_auiEncounter[2] >> m_auiEncounter[3]
+        >> m_auiEncounter[4] >> m_auiEncounter[5] >> m_auiEncounter[6];
 
     for (uint8 i = 0; i < INSTANCE_RUINS_AQ_MAX_ENCOUNTER; ++i)
         if (m_auiEncounter[i] == IN_PROGRESS || m_auiEncounter[i] > SPECIAL)           // Do not load an encounter as "In Progress" - reset it instead.

--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/ruins_of_ahnqiraj.h
@@ -20,12 +20,12 @@ enum
     TYPE_KURINNAXX          = 0,
     TYPE_GENERAL_ANDOROV    = 1,
     TYPE_RAJAXX             = 2,
-    INSTANCE_RUINS_AQ_MAX_ENCOUNTER           = 3,
+    TYPE_BURU               = 3,
+    TYPE_MOAM               = 4,
+    TYPE_AYAMISS            = 5,
+    TYPE_OSSIRIAN           = 6,
+    INSTANCE_RUINS_AQ_MAX_ENCOUNTER = 7,
 
-    TYPE_BURU               = 4,
-    TYPE_MOAM               = 5,
-    TYPE_AYAMISS            = 6,
-    TYPE_OSSIRIAN           = 7,
     TYPE_QIRAJI_GLADIATOR   = 8,
 };
 

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_bug_trio.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_bug_trio.cpp
@@ -56,6 +56,12 @@ struct boss_bug_trioAI : public ScriptedAI
         m_uiEvadeCheckTimer = 2500;
     }
 
+    void JustReachedHome() override
+    {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_BUG_TRIO, FAIL);
+    }
+
     void EnterEvadeMode() override
     {
         // If somehow a raid wipes during devour phase, restore normal speed/behavior
@@ -67,7 +73,7 @@ struct boss_bug_trioAI : public ScriptedAI
     {
         // Reset the slain bug count on pull
         if (m_pInstance)
-            m_pInstance->SetData(TYPE_BUG_TRIO, FAIL);
+            m_pInstance->SetData(TYPE_BUG_TRIO, IN_PROGRESS);
     }
 
     void MoveInLineOfSight(Unit* pWho) override

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_huhuran.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/boss_huhuran.cpp
@@ -70,6 +70,18 @@ struct boss_huhuranAI : public ScriptedAI
         ScriptedAI::MoveInLineOfSight(pWho);
     }
 
+    void Aggro(Unit* /*pWho*/) override
+    {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_HUHURAN, IN_PROGRESS);
+    }
+
+    void JustReachedHome() override
+    {
+        if (m_pInstance)
+            m_pInstance->SetData(TYPE_HUHURAN, FAIL);
+    }
+
     void JustDied(Unit*) override
     {
         if (m_pInstance)

--- a/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/instance_temple_of_ahnqiraj.cpp
+++ b/src/scripts/kalimdor/silithus/temple_of_ahnqiraj/instance_temple_of_ahnqiraj.cpp
@@ -163,7 +163,7 @@ bool instance_temple_of_ahnqiraj::IsEncounterInProgress() const
 {
     for (uint8 i = 0; i < MAX_ENCOUNTER; ++i)
     {
-        if (m_auiEncounter[i] == IN_PROGRESS)
+        if (m_auiEncounter[i] == IN_PROGRESS || m_auiEncounter[i] == SPECIAL)
             return true;
     }
 
@@ -332,12 +332,12 @@ void instance_temple_of_ahnqiraj::SetData(uint32 uiType, uint32 uiData)
         if (uiData == SPECIAL)
         {
             ++m_uiBugTrioDeathCount;
-            if (m_uiBugTrioDeathCount == 2)
+            if (m_uiBugTrioDeathCount >= 3)
                 SetData(TYPE_BUG_TRIO, DONE);
             // don't store any special data
             break;
         }
-        if (uiData == FAIL)
+        if (uiData == IN_PROGRESS)
             m_uiBugTrioDeathCount = 0;
         m_auiEncounter[uiType] = uiData;
         break;


### PR DESCRIPTION
There's currently a number of "encounter in progress" issues in Naxx even when no one is in combat.
This is due to the getAttackers() check which is too unreliable. It also shouldn't be blocking entrance when the raid is only fighting trash.  

Replaced the main check with the IsEncounterInProgress() function, which looks at the IN_PROGRESS status of each encounter.  
Since it should be possible to enter the map while an encounter is in progress but the raid is out of combat in at least 1 fight (Rajaxx), I included the combat check as well. This also helps prevent a raid lockout in case an encounter state somehow bugs out and gets stuck IN_PROGRESS.

Tested all the raid encounters to check if the progress state is properly set and cleared:
* Onyxia: Not implemented. instance_onyxia_lair.cpp is completely unused.
* MC: All bosses implemented but IsEncounterInProgress is hardcoded to return false.
* BWL: All bosses implemented except Flamegore.
* ZG: Not implemented and IsEncounterInProgress returns false with the comment "not active"
* AQ20: Only Kurinaxx and Rajaxx are implemented.
* AQ40: All bosses implemented except Bug Trio and Huhuran.
* Naxx: All implemented.

On the current core theres a hardcoded rule to only block entrance on Naxx, AQ40 and Ony. Is this intentional or should all the other raids be blocking as well?
