### PR TITLE
Implement creature melee distance correction.

### DIFF
--- a/sql/migrations/20180406031630_world.sql
+++ b/sql/migrations/20180406031630_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180406031630');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180406031630');
+-- Add your query below.
+
+-- Disable backing up for bosses.
+UPDATE `creature_template` SET `flags_extra`=`flags_extra`+32768 WHERE `rank`=3;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Movement/TargetedMovementGenerator.cpp
+++ b/src/game/Movement/TargetedMovementGenerator.cpp
@@ -332,8 +332,8 @@ bool TargetedMovementGeneratorMedium<T, D>::Update(T &owner, const uint32 & time
                     i_recheckBoundingRadius.Reset(3000);
                     if (Creature* creature = owner.ToCreature())
                     {
-                        if (!(creature->GetCreatureInfo()->flags_extra & CREATURE_FLAG_EXTRA_CHASE_GEN_NO_BACKING) && !creature->IsPet() && !i_target.getTarget()->IsMoving() && target_deep_in_bounds(owner, i_target.getTarget()))
-                            do_back_movement(owner, i_target.getTarget());
+                        if (!(creature->GetCreatureInfo()->flags_extra & CREATURE_FLAG_EXTRA_CHASE_GEN_NO_BACKING) && !creature->IsPet() && !i_target.getTarget()->IsMoving() && TargetDeepInBounds(owner, i_target.getTarget()))
+                            DoBackMovement(owner, i_target.getTarget());
                     }
                 }
         }
@@ -362,13 +362,13 @@ void TargetedMovementGeneratorMedium<T, D>::UpdateAsync(T &owner, uint32 /*diff*
 }
 
 template<class T, typename D>
-bool TargetedMovementGeneratorMedium<T, D>::target_deep_in_bounds(T &owner, Unit* target) const
+bool TargetedMovementGeneratorMedium<T, D>::TargetDeepInBounds(T &owner, Unit* target) const
 {
-    return target_bounds_pct_dist(owner, target, 0.8f);
+    return TargetWithinBoundsPercentDistance(owner, target, 0.8f);
 }
 
 template<class T, typename D>
-bool TargetedMovementGeneratorMedium<T, D>::target_bounds_pct_dist(T &owner, Unit* target, float pct) const
+bool TargetedMovementGeneratorMedium<T, D>::TargetWithinBoundsPercentDistance(T &owner, Unit* target, float pct) const
 {
     float radius =
         (target->GetObjectBoundingRadius() + owner.GetObjectBoundingRadius());
@@ -382,7 +382,7 @@ bool TargetedMovementGeneratorMedium<T, D>::target_bounds_pct_dist(T &owner, Uni
 }
 
 template<class T, typename D>
-void TargetedMovementGeneratorMedium<T, D>::do_back_movement(T &owner, Unit* target)
+void TargetedMovementGeneratorMedium<T, D>::DoBackMovement(T &owner, Unit* target)
 {
     float x, y, z;
     i_backing_up = true;

--- a/src/game/Movement/TargetedMovementGenerator.cpp
+++ b/src/game/Movement/TargetedMovementGenerator.cpp
@@ -257,7 +257,7 @@ bool TargetedMovementGeneratorMedium<T, D>::Update(T &owner, const uint32 & time
 
     bool interrupted = false;
     i_recheckDistance.Update(time_diff);
-    if (i_recheckDistance.Passed())
+    if (!i_backing_up && i_recheckDistance.Passed())
     {
         i_recheckDistance.Reset(100);
         //More distance let have better performance, less distance let have more sensitive reaction at target move.
@@ -283,6 +283,7 @@ bool TargetedMovementGeneratorMedium<T, D>::Update(T &owner, const uint32 & time
 
             if (!targetMoved)
                 targetMoved = !i_target->IsWithinDist3d(dest.x, dest.y, dest.z, 0.5f);
+
             // Chase movement may be interrupted
             if (!targetMoved)
                 if (owner.movespline->Finalized())
@@ -305,6 +306,9 @@ bool TargetedMovementGeneratorMedium<T, D>::Update(T &owner, const uint32 & time
 
     if (owner.movespline->Finalized())
     {
+        if (i_backing_up)
+            i_backing_up = false;
+
         if (owner.GetMotionMaster()->GetCurrentMovementGeneratorType() == CHASE_MOTION_TYPE || 
             owner.GetMotionMaster()->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
             static_cast<D*>(this)->MovementInform(owner);
@@ -319,6 +323,21 @@ bool TargetedMovementGeneratorMedium<T, D>::Update(T &owner, const uint32 & time
         }
         if (interrupted)
             owner.StopMoving();
+
+        if (i_recalculateTravel && (this->GetMovementGeneratorType() == CHASE_MOTION_TYPE))
+        {
+                i_recheckBoundingRadius.Update(time_diff);
+                if (i_recheckBoundingRadius.Passed())
+                {
+                    i_recheckBoundingRadius.Reset(3000);
+                    if (Creature* creature = owner.ToCreature())
+                    {
+                        if (!(creature->GetCreatureInfo()->flags_extra & CREATURE_FLAG_EXTRA_CHASE_GEN_NO_BACKING) && !creature->IsPet() && !i_target.getTarget()->IsMoving() && target_deep_in_bounds(owner, i_target.getTarget()))
+                            do_back_movement(owner, i_target.getTarget());
+                    }
+                }
+        }
+        
     }
     else if (i_recalculateTravel)
         owner.GetMotionMaster()->SetNeedAsyncUpdate();
@@ -340,6 +359,38 @@ void TargetedMovementGeneratorMedium<T, D>::UpdateAsync(T &owner, uint32 /*diff*
     // Lock async updates for safety, see Unit::asyncMovesplineLock doc
     ACE_Guard<ACE_Thread_Mutex> guard(owner.asyncMovesplineLock);
     _setTargetLocation(owner);
+}
+
+template<class T, typename D>
+bool TargetedMovementGeneratorMedium<T, D>::target_deep_in_bounds(T &owner, Unit* target) const
+{
+    return target_bounds_pct_dist(owner, target, 0.8f);
+}
+
+template<class T, typename D>
+bool TargetedMovementGeneratorMedium<T, D>::target_bounds_pct_dist(T &owner, Unit* target, float pct) const
+{
+    float radius =
+        (target->GetObjectBoundingRadius() + owner.GetObjectBoundingRadius());
+    radius *= pct;
+
+    float dx = target->GetPositionX() - owner.GetPositionX();
+    float dy = target->GetPositionY() - owner.GetPositionY();
+    float dz = target->GetPositionZ() - owner.GetPositionZ();
+
+    return dx * dx + dy * dy + dz * dz < radius * radius;
+}
+
+template<class T, typename D>
+void TargetedMovementGeneratorMedium<T, D>::do_back_movement(T &owner, Unit* target)
+{
+    float x, y, z;
+    i_backing_up = true;
+    target->GetClosePoint(x, y, z, target->GetObjectBoundingRadius() + owner.GetObjectBoundingRadius(), 1.0f, i_angle, &owner);
+    Movement::MoveSplineInit init(owner, "TargetedMovementGenerator");
+    init.MoveTo(x, y, z, MOVE_WALK_MODE);
+    init.SetWalk(true);
+    init.Launch();
 }
 
 //-----------------------------------------------//

--- a/src/game/Movement/TargetedMovementGenerator.h
+++ b/src/game/Movement/TargetedMovementGenerator.h
@@ -39,8 +39,8 @@ class MANGOS_DLL_SPEC TargetedMovementGeneratorMedium
 {
     protected:
         TargetedMovementGeneratorMedium(Unit &target, float offset, float angle) :
-            TargetedMovementGeneratorBase(target), i_recheckDistance(0), i_offset(offset),
-            i_angle(angle), i_recalculateTravel(false), i_targetReached(false),
+            TargetedMovementGeneratorBase(target), i_recheckDistance(0), i_recheckBoundingRadius(0), i_offset(offset),
+            i_angle(angle), i_recalculateTravel(false), i_targetReached(false), i_backing_up(false),
             i_reachable(true), _targetLastX(0), _targetLastY(0), _targetLastZ(0), _targetOnTransport(false)
         {
         }
@@ -64,15 +64,21 @@ class MANGOS_DLL_SPEC TargetedMovementGeneratorMedium
         void _setTargetLocation(T &);
 
         ShortTimeTracker i_recheckDistance;
+        ShortTimeTracker i_recheckBoundingRadius;
         float i_offset;
         float i_angle;
         bool i_recalculateTravel : 1;
         bool i_targetReached : 1;
         bool i_reachable;
+        bool i_backing_up;
         float _targetLastX;
         float _targetLastY;
         float _targetLastZ;
         bool  _targetOnTransport;
+    private:
+        void do_back_movement(T &, Unit* target);
+        bool target_deep_in_bounds(T &, Unit* target) const;
+        bool target_bounds_pct_dist(T &, Unit* target, float pct) const;
 };
 
 template<class T>

--- a/src/game/Movement/TargetedMovementGenerator.h
+++ b/src/game/Movement/TargetedMovementGenerator.h
@@ -76,9 +76,9 @@ class MANGOS_DLL_SPEC TargetedMovementGeneratorMedium
         float _targetLastZ;
         bool  _targetOnTransport;
     private:
-        void do_back_movement(T &, Unit* target);
-        bool target_deep_in_bounds(T &, Unit* target) const;
-        bool target_bounds_pct_dist(T &, Unit* target, float pct) const;
+        void DoBackMovement(T &, Unit* target);
+        bool TargetDeepInBounds(T &, Unit* target) const;
+        bool TargetWithinBoundsPercentDistance(T &, Unit* target, float pct) const;
 };
 
 template<class T>

--- a/src/game/Objects/Creature.h
+++ b/src/game/Objects/Creature.h
@@ -64,6 +64,7 @@ enum CreatureFlagsExtra
     CREATURE_FLAG_EXTRA_KEEP_POSITIVE_AURAS_ON_EVADE = 0x00001000,       // creature keeps positive auras at reset
     CREATURE_FLAG_EXTRA_ALWAYS_CRUSH                 = 0x00002000,       // creature always roll a crushing melee outcome when not miss/crit/dodge/parry/block
     CREATURE_FLAG_EXTRA_IMMUNE_AOE                   = 0x00004000,       // creature is immune to AoE
+    CREATURE_FLAG_EXTRA_CHASE_GEN_NO_BACKING         = 0x00008000,       // creature does not move back when target is within bounding radius
 };
 
 // GCC have alternative #pragma pack(N) syntax and old gcc version not support pack(push,N), also any gcc version not support it at some platform


### PR DESCRIPTION
Fixes issue https://github.com/LightsHope/issues/issues/179

Ported from CoreCraft, credits to them.

If you enter a creature's bounding radius, it is supposed to move back a bit. This feature has always existed, you can see mobs doing it in Joana's videos. https://youtu.be/SwLjJH8LXfc?t=161