### PR TITLE
Eye of Kilrogg level

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -3458,6 +3458,9 @@ void Spell::EffectSummonGuardian(SpellEffectIndex eff_idx)
                 }
             }
         }
+        // Eye of Kilrog
+        if (m_spellInfo->Effect[eff_idx] == SPELL_EFFECT_SUMMON_POSSESSED)
+            level = m_caster->getLevel();
     }
 
     // select center of summon position


### PR DESCRIPTION
Eye of Kilrogg isn't a guardian but the core uses SummonGuardian for it so its falling under the new guardian level rules. Added an exception since it should match the player level.