### PR TITLE
Put trash linked to mobs with instance-wide aggro in combat with instance when source is pulled

### DIFF
--- a/src/game/Group/CreatureLinkingMgr.cpp
+++ b/src/game/Group/CreatureLinkingMgr.cpp
@@ -530,9 +530,17 @@ void CreatureLinkingHolder::ProcessSlave(CreatureLinkingEvent eventType, Creatur
                 return;
 
             if (pSlave->isInCombat())
-                pSlave->SetInCombatWith(pEnemy);
-            else
+            {
+                if (pSource->GetMap()->IsDungeon() && (pSource->GetCreatureInfo()->flags_extra & CREATURE_FLAG_EXTRA_AGGRO_ZONE))
+                    pSlave->SetInCombatWithZone();
+                else
+                    pSlave->SetInCombatWith(pEnemy);
+            }
+            else {
                 pSlave->AI()->AttackStart(pEnemy);
+                if (pSource->GetMap()->IsDungeon() && (pSource->GetCreatureInfo()->flags_extra & CREATURE_FLAG_EXTRA_AGGRO_ZONE))
+                    pSlave->SetInCombatWithZone();
+            }
         }
         break;
     case LINKING_EVENT_EVADE:


### PR DESCRIPTION
CreatureLinkingMgr will now put trash that is pulled by a boss they are linked to in combat with entire instance if the boss has flag CREATURE_FLAG_EXTRA_AGGRO_ZONE. This to avoid exploits where trash is linked to a boss and intended to be killed, but was previously skippable by having a hunter/rogue pull boss then instantly feign/vanish.