### PR TITLE
Additional Naxxramas changes

### DIFF
--- a/sql/migrations/20180504110404_world.sql
+++ b/sql/migrations/20180504110404_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180504110404');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180504110404');
+-- Add your query below.
+
+-- Necro Stalker immune to CC
+UPDATE `creature_template` SET `MechanicImmuneMask` = 1023393531 WHERE `entry` = 16453;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -1364,6 +1364,7 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         void SetCharmGuid(ObjectGuid charm) { SetGuidValue(UNIT_FIELD_CHARM, charm); }
         ObjectGuid const& GetTargetGuid() const { return GetGuidValue(UNIT_FIELD_TARGET); }
         void SetTargetGuid(ObjectGuid targetGuid) { SetGuidValue(UNIT_FIELD_TARGET, targetGuid); }
+        void ClearTarget() { SetTargetGuid(ObjectGuid()); }
         ObjectGuid const& GetChannelObjectGuid() const { return GetGuidValue(UNIT_FIELD_CHANNEL_OBJECT); }
         void SetChannelObjectGuid(ObjectGuid targetGuid) { SetGuidValue(UNIT_FIELD_CHANNEL_OBJECT, targetGuid); }
 

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/instance_naxxramas.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/instance_naxxramas.cpp
@@ -214,10 +214,15 @@ void instance_naxxramas::OnCreatureEnterCombat(Creature * creature)
 
 bool instance_naxxramas::WingsAreCleared()
 {
-    return GetData(TYPE_MAEXXNA) == DONE
-        && GetData(TYPE_THADDIUS) == DONE
-        && GetData(TYPE_LOATHEB) == DONE
-        && GetData(TYPE_FOUR_HORSEMEN) == DONE;
+    // All bosses must be dead, not just the end bosses. Some bosses aren't gated
+    // so we just check them all
+    for (int i = 0; i < TYPE_SAPPHIRON; ++i)
+    {
+        if (GetData(i) != DONE)
+            return false;
+    }
+
+    return true;
 }
 
 void instance_naxxramas::UpdateAutomaticBossEntranceDoor(NaxxGOs which, uint32 uiData, int requiredPreBossData)
@@ -1683,14 +1688,16 @@ struct mob_toxic_tunnelAI : public ScriptedAI
                 _evadeTimer -= diff;
         }
 
-        /*if (checktime <= diff)
+        // creature_template_addons should make this aura permanent, but check anyway due
+        // to some reports of it not recasting
+        if (checktime <= diff)
         {
             checktime = 5000;
             if (!m_creature->HasAura(28370))
                 m_creature->CastSpell(m_creature, 28370, true);
         }
         else
-            checktime -= diff;*/
+            checktime -= diff;
     }
 };
 


### PR DESCRIPTION
Prevent Gothik from targetting people in the other side of the room - no more running through the gate, hopefully
Delay Harvest/Shadowbolt casts if they would occur near the teleport, solves an issue with a visual bug
Necro Stalkers can no longer be CCed
Players that are feigning death on 1 side of Gothik's room will now properly be counted towards the total players on that side