### PR TITLE
Add String Terminator to Transaction Items

### DIFF
--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -2816,7 +2816,7 @@ void World::LogTransaction(PlayerTransactionData const& data)
         std::stringstream items;
         for (int i = 0; i < TransactionPart::MAX_TRANSACTION_ITEMS; ++i)
             if (part.itemsEntries[i])
-                items << uint32(part.itemsEntries[i]) << ":" << uint32(part.itemsCount[i]) << ":" << part.itemsGuid[i];
+                items << uint32(part.itemsEntries[i]) << ":" << uint32(part.itemsCount[i]) << ":" << part.itemsGuid[i] << ";";
         logStmt.addString(items.str());
     }
     logStmt.Execute();


### PR DESCRIPTION
Adding a `;` in the end of each itemEntries will make parsing much easier and error free.