### PR TITLE
Prevent combat drop when creature charms expire while the creature is in combat

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -3181,6 +3181,7 @@ void Aura::HandleModCharm(bool apply, bool Real)
         // Clear threat list for targets engaged while charmed
         target->DeleteThreatList();
         target->getHostileRefManager().deleteReferences();
+        target->AttackStop();
 
         // Re-add the target to the caster's hated list to prevent combat dropping.
         // Combat reset timer kicks in once the hated list is empty. If the caster is

--- a/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
+++ b/src/scripts/eastern_kingdoms/eastern_plaguelands/naxxramas/boss_kelthuzad.cpp
@@ -521,6 +521,7 @@ struct boss_kelthuzadAI : public ScriptedAI
                 break;
             case EVENT_PUT_IN_COMBAT:
                 m_creature->SetInCombatState(false);
+                m_creature->UpdateCombatState(true);
                 m_creature->SetInCombatWithZone();
                 hasPutInCombat = true;
                 break;


### PR DESCRIPTION
- The combat end timer will begin to tick once a unit's hated list is empty. Therefore, we should ensure that the caster is still on the threat list after a successful charm
- We should potentially restore a unit's threat list from before the charm rather than wiping it and only adding the caster
- Removed Kel'Thuzad specific MC handling
- Ensure Kel'Thuzad properly enters combat with the instance