### PR TITLE
Remove Mind Control threat transfer

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -11418,10 +11418,39 @@ protected:
     Unit* _to;
 };
 
+class ThreatRemovalDo
+{
+public:
+    ThreatRemovalDo(Unit* from, Unit* caster) : _from(from), _caster(caster) {}
+    void operator()(Unit* unit)
+    {
+        if (unit == _from || unit == _caster)
+            return;
+        if (!unit->IsValidAttackTarget(_caster))
+            return;
+
+        if (unit->getThreatManager().getThreat(_from) > 0.1f)
+        {
+            unit->getThreatManager().modifyThreatPercent(_from, -100);
+            unit->AddThreat(_caster, 1.0f);
+        }
+    }
+protected:
+    Unit * _from;
+    Unit* _caster;
+};
+
 void Unit::TransferAttackersThreatTo(Unit* unit)
 {
     ThreatTransferDo u_do(this, unit);
     MaNGOS::CreatureWorker<ThreatTransferDo> worker(this, u_do);
+    Cell::VisitGridObjects(this, worker, 50.0f);
+}
+
+void Unit::RemoveAttackersThreat(Unit* unit)
+{
+    ThreatRemovalDo u_do(this, unit);
+    MaNGOS::CreatureWorker<ThreatRemovalDo> worker(this, u_do);
     Cell::VisitGridObjects(this, worker, 50.0f);
 }
 

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -11427,8 +11427,7 @@ void Unit::TransferAttackersThreatTo(Unit* unit)
 
 void Unit::RemoveAttackersThreat(Unit* owner)
 {
-    Unit::AttackerSet attackers = getAttackers();
-    for (Unit::AttackerSet::iterator itr = attackers.begin(); itr != attackers.end(); ++itr)
+    for (AttackerSet::iterator itr = m_attackers.begin(); itr != m_attackers.end(); ++itr)
     {
         (*itr)->getThreatManager().modifyThreatPercent(this, -100);
         if (owner)

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -11418,28 +11418,6 @@ protected:
     Unit* _to;
 };
 
-class ThreatRemovalDo
-{
-public:
-    ThreatRemovalDo(Unit* from, Unit* caster) : _from(from), _caster(caster) {}
-    void operator()(Unit* unit)
-    {
-        if (unit == _from || unit == _caster)
-            return;
-        if (!unit->IsValidAttackTarget(_caster))
-            return;
-
-        if (unit->getThreatManager().getThreat(_from) > 0.1f)
-        {
-            unit->getThreatManager().modifyThreatPercent(_from, -100);
-            unit->AddThreat(_caster, 1.0f);
-        }
-    }
-protected:
-    Unit * _from;
-    Unit* _caster;
-};
-
 void Unit::TransferAttackersThreatTo(Unit* unit)
 {
     ThreatTransferDo u_do(this, unit);
@@ -11447,11 +11425,15 @@ void Unit::TransferAttackersThreatTo(Unit* unit)
     Cell::VisitGridObjects(this, worker, 50.0f);
 }
 
-void Unit::RemoveAttackersThreat(Unit* unit)
+void Unit::RemoveAttackersThreat(Unit* owner)
 {
-    ThreatRemovalDo u_do(this, unit);
-    MaNGOS::CreatureWorker<ThreatRemovalDo> worker(this, u_do);
-    Cell::VisitGridObjects(this, worker, 50.0f);
+    Unit::AttackerSet attackers = getAttackers();
+    for (Unit::AttackerSet::iterator itr = attackers.begin(); itr != attackers.end(); ++itr)
+    {
+        (*itr)->getThreatManager().modifyThreatPercent(this, -100);
+        if (owner)
+            (*itr)->AddThreat(owner, 1.0f);
+    }
 }
 
 void Unit::SetMovement(UnitMovementType pType)

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -1891,6 +1891,7 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
 
         // Nostalrius - en fin de CM par exemple
         void TransferAttackersThreatTo(Unit* unit);
+        void RemoveAttackersThreat(Unit* unit);
 
         bool IsInPartyWith(Unit const* unit) const;
         bool IsInRaidWith(Unit const* unit) const;

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -1891,7 +1891,7 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
 
         // Nostalrius - en fin de CM par exemple
         void TransferAttackersThreatTo(Unit* unit);
-        void RemoveAttackersThreat(Unit* unit);
+        void RemoveAttackersThreat(Unit* owner);
 
         bool IsInPartyWith(Unit const* unit) const;
         bool IsInRaidWith(Unit const* unit) const;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2895,8 +2895,8 @@ void Unit::ModPossess(Unit* target, bool apply, AuraRemoveMode m_removeMode)
     }
     else
     {
-        // On transfert la menace vers celui qui a CM
-        target->TransferAttackersThreatTo(caster);
+        // Clear threat generated when MC ends
+        target->RemoveAttackersThreat(caster);
 
         // spell is interrupted on channeled aura removal, don't need to interrupt here
         //caster->InterruptSpell(CURRENT_CHANNELED_SPELL);


### PR DESCRIPTION
Currently MC is both causing a high amount of threat on the MC mob and transfering all the threat the mob caused to the priest. This means when an MC breaks on Razuvious both the Deathknight and the boss will go straight to the priest.

Going through retail videos this transfer doesnt seem to happen at all:
[EG kill Instructor Razuvious (Jul 30, 2006)](https://mega.nz/#!e4F0CIrJ!0RM4QMmph6mhFbNBByDYNFfOtw7LnvtgliRFPkbJxf8)  
2:30: Triangle breaks, goes for priest while the boss switches to a warrior (no taunt) kills him and switches to rogue.

[Kaizen Vs. Instructor Razuvious (Jul 25, 2006)](https://mega.nz/#!vsclzCrY!lbtdyDod7dApLNMha9-TTwiuKiqG_gJweqkW1r7h1Sg)  
1:30: All Deathknights break, Boss starts killing rogues.
3:15: Circle dies, Boss switches to rogues.

[Instructor Razuvious Naxxramas Kill (Jun 29, 2006)](https://mega.nz/#!q4VVGADA!s02JPYQm9MlBK8sit-c0Q4tNN1c5MqpH3EFciRDgu4o)  
1:25: Moon breaks, boss turns to melee with no taunt.

Switched the transfer mechanic with a threat removal while adding a minimal amount of threat to the caster to ensure it stays in combat with the target.


