### PR TITLE
Fix to Anubisath Defenders phase setting

### DIFF
--- a/src/game/AI/CreatureEventAI.cpp
+++ b/src/game/AI/CreatureEventAI.cpp
@@ -111,6 +111,14 @@ CreatureEventAI::CreatureEventAI(Creature *c) : CreatureAI(c)
 
     m_InvinceabilityHpLevel = 0;
 
+    //Handle Spawned Events
+    c->SetAI(this);
+    if (!m_bEmptyList)
+    {
+        for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
+            if (i->Event.event_type == EVENT_T_SPAWNED)
+                ProcessEvent(*i);
+    }
     Reset();
 }
 

--- a/src/game/AI/CreatureEventAI.cpp
+++ b/src/game/AI/CreatureEventAI.cpp
@@ -111,13 +111,6 @@ CreatureEventAI::CreatureEventAI(Creature *c) : CreatureAI(c)
 
     m_InvinceabilityHpLevel = 0;
 
-    //Handle Spawned Events
-    if (!m_bEmptyList)
-    {
-        for (CreatureEventAIList::iterator i = m_CreatureEventAIList.begin(); i != m_CreatureEventAIList.end(); ++i)
-            if (i->Event.event_type == EVENT_T_SPAWNED)
-                ProcessEvent(*i);
-    }
     Reset();
 }
 

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -213,8 +213,6 @@ void Creature::AddToWorld()
 
     if (!i_AI)
         AIM_Initialize();
-    if (i_AI)
-        i_AI->JustRespawned();
     if (!bWasInWorld && m_zoneScript)
         m_zoneScript->OnCreatureCreate(this);
 }

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -213,6 +213,8 @@ void Creature::AddToWorld()
 
     if (!i_AI)
         AIM_Initialize();
+    if (i_AI)
+        i_AI->JustRespawned();
     if (!bWasInWorld && m_zoneScript)
         m_zoneScript->OnCreatureCreate(this);
 }

--- a/src/game/Objects/Creature.h
+++ b/src/game/Objects/Creature.h
@@ -574,6 +574,7 @@ class MANGOS_DLL_SPEC Creature : public Unit
         bool IsInEvadeMode() const;
 
         bool AIM_Initialize();
+        void SetAI(CreatureAI * ai) { i_AI = ai; }
 
         CreatureAI* AI() { return i_AI; }
         CreatureAI const* AI() const { return i_AI; }


### PR DESCRIPTION
The Anubisath AI gives it a random phase on spawn but currently the processing of the spawn event is being done on the CreatureEventAI creator. 
Since the creature doesn't have an AI yet at this point the random phase script is aborted.

Added a SetAI to set it before spawn events are processed.