### PR TITLE
Require Email Verification for joindate bigger then defined in config file.

### DIFF
--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -431,14 +431,7 @@ bool AuthSocket::_HandleLogonChallenge()
             if (requireEmailSince > 0)
             {
                 int32 t = (*result)[10].GetInt32();
-                if (t >= requireEmailSince)
-                {
-                    requireVerification = requireVerification && true;
-                }
-                else
-                {
-                    requireVerification = requireVerification && false;
-                }
+                requireVerification = requireVerification && (t >= requireEmailSince);
             }
 
             if (requireVerification && !verified)

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -424,13 +424,13 @@ bool AuthSocket::_HandleLogonChallenge()
 
             // Prevent login if the user's email address has not been verified
             bool requireVerification = sConfig.GetBoolDefault("ReqEmailVerification", false);
-            uint32 requireEmailSince = sConfig.GetIntDefault("ReqEmailSince", 0);
+            int32 requireEmailSince = sConfig.GetIntDefault("ReqEmailSince", 0);
             bool verified = (*result)[7].GetBool();
             
             // Prevent login if the user's join date is bigger than the timestamp in configuration
             if (requireEmailSince > 0)
             {
-                uint32 t = (*result)[10].GetInt32();
+                uint32 t = (*result)[10].GetUInt32();
                 requireVerification = requireVerification && (t >= requireEmailSince);
             }
 

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -424,13 +424,13 @@ bool AuthSocket::_HandleLogonChallenge()
 
             // Prevent login if the user's email address has not been verified
             bool requireVerification = sConfig.GetBoolDefault("ReqEmailVerification", false);
-            int32 requireEmailSince = sConfig.GetIntDefault("ReqEmailSince", 0);
+            uint32 requireEmailSince = sConfig.GetIntDefault("ReqEmailSince", 0);
             bool verified = (*result)[7].GetBool();
             
             // Prevent login if the user's join date is bigger than the timestamp in configuration
             if (requireEmailSince > 0)
             {
-                int32 t = (*result)[10].GetInt32();
+                uint32 t = (*result)[10].GetInt32();
                 requireVerification = requireVerification && (t >= requireEmailSince);
             }
 

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -417,18 +417,33 @@ bool AuthSocket::_HandleLogonChallenge()
     {
         ///- Get the account details from the account table
         // No SQL injection (escaped user name)
-        result = LoginDatabase.PQuery("SELECT sha_pass_hash,id,locked,last_ip,v,s,security,email_verif,geolock_pin,email FROM account WHERE username = '%s'",_safelogin.c_str ());
+        result = LoginDatabase.PQuery("SELECT sha_pass_hash,id,locked,last_ip,v,s,security,email_verif,geolock_pin,email,UNIX_TIMESTAMP(joindate) FROM account WHERE username = '%s'",_safelogin.c_str ());
         if (result)
         {
             Field* fields = result->Fetch();
 
             // Prevent login if the user's email address has not been verified
             bool requireVerification = sConfig.GetBoolDefault("ReqEmailVerification", false);
+            int32 requireEmailSince = sConfig.GetIntDefault("ReqEmailSince", 0);
             bool verified = (*result)[7].GetBool();
+            
+            // Prevent login if the user's join date is bigger than the timestamp in configuration
+            if (requireEmailSince > 0)
+            {
+                int32 t = (*result)[10].GetInt32();
+                if (t >= requireEmailSince)
+                {
+                    requireVerification = requireVerification && true;
+                }
+                else
+                {
+                    requireVerification = requireVerification && false;
+                }
+            }
 
             if (requireVerification && !verified)
             {
-                 BASIC_LOG("[AuthChallenge] Account '%s' using IP '%s 'email address requires email verification - rejecting login", _login.c_str(), get_remote_address().c_str());
+                BASIC_LOG("[AuthChallenge] Account '%s' using IP '%s 'email address requires email verification - rejecting login", _login.c_str(), get_remote_address().c_str());
                 pkt << (uint8)WOW_FAIL_UNKNOWN_ACCOUNT;
                 send((char const*)pkt.contents(), pkt.size());
                 return true;
@@ -796,7 +811,7 @@ bool AuthSocket::_HandleLogonProof()
         else if (GeographicalLockCheck())
         {
             BASIC_LOG("Account '%s' (%u) using IP '%s' has been geolocked", _login.c_str(), _accountId, get_remote_address().c_str()); // todo, add additional logging info
-            
+
             auto pin = urand(100000, 999999); // check rand32_max
             auto result = LoginDatabase.PExecute("UPDATE account SET geolock_pin = %u WHERE username = '%s'",
                 pin, _safelogin.c_str());
@@ -1295,7 +1310,7 @@ bool AuthSocket::VerifyPinData(uint32 pin, const PINData& clientData)
 
     // convert the PIN to bytes (for ex. '1234' to {1, 2, 3, 4})
     std::vector<uint8> pinBytes;
-	    
+
     while (pin != 0)
     {
         pinBytes.push_back(pin % 10);
@@ -1324,7 +1339,7 @@ bool AuthSocket::VerifyPinData(uint32 pin, const PINData& clientData)
     sha.UpdateData(serverSecuritySalt.AsByteArray());
     sha.UpdateData(pinBytes.data(), pinBytes.size());
     sha.Finalize();
-    
+
     BigNumber hash, clientHash;
     hash.SetBinary(sha.GetDigest(), sha.GetLength());
     clientHash.SetBinary(clientData.hash, 20);
@@ -1353,7 +1368,7 @@ uint32 AuthSocket::GenerateTotpPin(const std::string& secret, int interval) {
     uint64 now = static_cast<uint64>(time);
     uint64 step = static_cast<uint64>((floor(now / 30))) + interval;
     EndianConvertReverse(step);
-    
+
     HmacHash hmac(decoded_key.data(), key_size);
     hmac.UpdateData((uint8*)&step, sizeof(step));
     hmac.Finalize();

--- a/src/realmd/realmd.conf.dist.in
+++ b/src/realmd/realmd.conf.dist.in
@@ -114,6 +114,11 @@ ConfVersion=2010062001
 #        Default: 0 (No verification required)
 #                 1 (Verification required)
 #
+#    ReqEmailSince
+#        Require the Email Verification Since the Timestamp
+#        Default: 0 (Disabled)
+#                 1530302395 (Timestamp)
+#
 #    GeoLocking
 #        Blocks account logins when a change in geographical location is detected
 #        Default: 0
@@ -163,6 +168,7 @@ WrongPass.MaxCount = 0
 WrongPass.BanTime = 600
 WrongPass.BanType = 0
 ReqEmailVerification = 0
+ReqEmailSince = 0
 GeoLocking = 0
 SendMail = 0
 MailFrom = ""


### PR DESCRIPTION
When `ReqEmailVerification` is `true` and the `joindate` of the account is bigger then timestamp defined in `ReqEmailSince` (realmd.conf) prevents account to login without the email verified.