### PR TITLE
Allow daze snare stacking.

### DIFF
--- a/sql/migrations/20180705094551_world.sql
+++ b/sql/migrations/20180705094551_world.sql
@@ -1,0 +1,31 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180705094551');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180705094551');
+-- Add your query below.
+
+
+REPLACE INTO `spell_mod` (`Id`, `AttributesEx`, `Comment`) VALUES 
+('5101', '262144', 'Daze spell attribute'),
+('5116', '262144', 'Daze spell attribute'),
+('12323', '262144', 'Daze spell attribute'),
+('13496', '262144', 'Daze spell attribute'),
+('17174', '262144', 'Daze spell attribute'),
+('22914', '262144', 'Daze spell attribute'),
+('23600', '262144', 'Daze spell attribute'),
+('26379', '262144', 'Daze spell attribute'),
+('27634', '262144', 'Daze spell attribute');
+
+UPDATE `spell_mod` SET `AttributesEx`='262144' WHERE `Id`=15571;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -612,7 +612,8 @@ SpellSpecific GetSpellSpecific(uint32 spellId)
                 return SPELL_NEGATIVE_HASTE;
 
     // Movement speed reduction
-    if (IsSpellHaveSingleAura(spellInfo, SPELL_AURA_MOD_DECREASE_SPEED))
+    // Concussive Shot is not affected
+    if (IsSpellHaveSingleAura(spellInfo, SPELL_AURA_MOD_DECREASE_SPEED) && spellInfo->DmgClass != SPELL_DAMAGE_CLASS_RANGED)
         return SPELL_SNARE;
 
     return SPELL_NORMAL;

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -612,8 +612,8 @@ SpellSpecific GetSpellSpecific(uint32 spellId)
                 return SPELL_NEGATIVE_HASTE;
 
     // Movement speed reduction
-    // Concussive Shot is not affected
-    if (IsSpellHaveSingleAura(spellInfo, SPELL_AURA_MOD_DECREASE_SPEED) && spellInfo->DmgClass != SPELL_DAMAGE_CLASS_RANGED)
+    // Dazes are not affected
+    if (IsSpellHaveSingleAura(spellInfo, SPELL_AURA_MOD_DECREASE_SPEED) && !(spellInfo->AttributesEx & SPELL_ATTR_EX_UNK18))
         return SPELL_SNARE;
 
     return SPELL_NORMAL;


### PR DESCRIPTION
Video evidence here https://github.com/LightsHope/issues/issues/439

Out of ideas what to do about this one.
Concussive is stacking with Wing Clip and in the same video we have hamstring not stacking with frostbolt so the mechanic is clearly active.
I don't see anything special about the Concussive spell that would warrant it not being affected, its a snare like any other. It doesn't have any particular attribute that other snares don't have.