### PR TITLE
Fix deadlocking update script events iterator

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -1004,13 +1004,12 @@ void Map::Update(uint32 t_diff)
 
 void Map::UpdateScriptedEvents()
 {
-    for (auto itr = m_mScriptedEvents.begin(); itr != m_mScriptedEvents.end(); ++itr)
+    for (auto itr = m_mScriptedEvents.begin(); itr != m_mScriptedEvents.end();)
     {
         if (itr->second.UpdateEvent())
-        {
-            itr = m_mScriptedEvents.erase(itr);
-            continue;
-        }
+            m_mScriptedEvents.erase(itr++);
+        else
+            ++itr;
     }
 }
 


### PR DESCRIPTION
Incorrect method to erase map element while traversing in iterator causes deadlock. After erasing the finished script, it will look at previous script and call UpdateEvent again and deleting it if it has already completed. Once map is empty it will infinite loop and deadlock entire server.