### PR TITLE
Pre 1.10 Bonereaver's Edge proc

### DIFF
--- a/sql/migrations/20180704192642_world.sql
+++ b/sql/migrations/20180704192642_world.sql
@@ -1,0 +1,18 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180704192642');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180704192642');
+-- Add your query below.
+
+UPDATE `item_template` SET `spellid_1`='15280' WHERE `entry`=17076 AND `patch`=0;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
https://wow.gamepedia.com/Bonereaver%27s_Edge
http://web.archive.org/web/20050501051833/http://wow.allakhazam.com:80/db/item.html?witem=17076

BRE's proc spell is much stronger than it should be but since the spell ID never changed we can't accurately reproduce the old BRE.
This pull changes the pre 1.10 spell to this one: https://vanillawowdb.com/?spell=15280 its the same armor reduction but with a different duration: 20 seconds (should be 10 seconds pre 1.10, 60 seconds pre 1.7).

Another alternative would be using the unused spells 5508 and 5480 and modify their values. The proc effects would be patch accurate but the tooltips wouldn't match the effects.