### PR TITLE
Fix to damage mods and bonus weapon damage interaction

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2768,6 +2768,9 @@ uint32 Unit::CalculateDamage(WeaponAttackType attType, bool normalized, uint8 in
         }
     }
 
+    if (min_damage < 0) min_damage = 0.0f;
+    if (max_damage < 0) max_damage = 0.0f;
+
     if (min_damage > max_damage)
         std::swap(min_damage, max_damage);
 

--- a/src/game/StatSystem.cpp
+++ b/src/game/StatSystem.cpp
@@ -434,6 +434,7 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     {
         base_value = 0.0f;
         total_value = 0.0f;
+        total_phys = 0.0f;
     }
 
     min_damage = ((base_value + weapon_mindamage) * base_pct + total_value + total_phys) * total_pct;


### PR DESCRIPTION
Fixes the issue with Curse of Weakness and other damage mods being applied to the bonus damage some weapons have, like Heartseeking Crossbow, and reducing the damage to 0.