### PR TITLE
Prevent auto attacking friendly targets

### DIFF
--- a/src/game/AI/ScriptedGuardAI.cpp
+++ b/src/game/AI/ScriptedGuardAI.cpp
@@ -154,7 +154,7 @@ void guardAI::UpdateAI(const uint32 diff)
                 //Set our global cooldown
                 GlobalCooldown = GENERIC_CREATURE_COOLDOWN;
             }
-            else m_creature->AttackerStateUpdate(m_creature->getVictim());
+            else DoMeleeAttackIfReady();
 
             m_creature->resetAttackTimer();
         }

--- a/src/game/Objects/GameObject.cpp
+++ b/src/game/Objects/GameObject.cpp
@@ -218,7 +218,7 @@ public:
         if (!i_trap->CanSeeInWorld(u))
             return false;
         bool _isTotem = u->GetTypeId() == TYPEID_UNIT && ((Creature*)u)->IsTotem();
-        if (u->isAlive() && i_trap->IsWithinDistInMap(u, _isTotem ? i_range / 3.0f : i_range) && i_trapOwner->_IsValidAttackTarget(u))
+        if (u->isAlive() && i_trap->IsWithinDistInMap(u, _isTotem ? i_range / 3.0f : i_range) && i_trapOwner->IsValidAttackTarget(u))
         {
             i_range = i_trap->GetDistance(u);
             return true;

--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -518,7 +518,7 @@ Player::Player(WorldSession *session) : Unit(),
     m_deathTimer = 0;
     m_deathExpireTime = 0;
 
-    m_swingErrorMsg = 0;
+    m_swingErrorMsg = ATTACK_RESULT_OK;
 
     for (int j = 0; j < PLAYER_MAX_BATTLEGROUND_QUEUES; ++j)
     {
@@ -1186,6 +1186,14 @@ struct UpdateAttackersCombatHelper
     }
     Player* player;
 };
+
+AutoAttackCheckResult Player::CanAutoAttackTarget(Unit const* pVictim) const
+{
+    if (!IsValidAttackTarget(pVictim))
+        return ATTACK_RESULT_FRIENDLY_TARGET;
+
+    return Unit::CanAutoAttackTarget(pVictim);
+}
 
 void Player::Update(uint32 update_diff, uint32 p_time)
 {

--- a/src/game/Objects/Player.h
+++ b/src/game/Objects/Player.h
@@ -1634,8 +1634,8 @@ class MANGOS_DLL_SPEC Player final: public Unit
         void SendLogXPGain(uint32 GivenXP,Unit* victim,uint32 RestXP);
 
 
-        uint8 LastSwingErrorMsg() const { return m_swingErrorMsg; }
-        void SwingErrorMsg(uint8 val) { m_swingErrorMsg = val; }
+        AutoAttackCheckResult GetLastSwingErrorMsg() const { return m_swingErrorMsg; }
+        void SetSwingErrorMsg(AutoAttackCheckResult val) { m_swingErrorMsg = val; }
 
         // notifiers
         void SendAttackSwingCantAttack();
@@ -1646,6 +1646,7 @@ class MANGOS_DLL_SPEC Player final: public Unit
         void SendAttackSwingBadFacingAttack();
         void SendAutoRepeatCancel();
         void SendExplorationExperience(uint32 Area, uint32 Experience);
+        AutoAttackCheckResult CanAutoAttackTarget(Unit const*) const override;
 
         void ResetInstances(InstanceResetMethod method);
         void SendResetInstanceSuccess(uint32 MapId);
@@ -2374,7 +2375,7 @@ class MANGOS_DLL_SPEC Player final: public Unit
         bool m_canParry;
         bool m_canBlock;
         bool m_canDualWield;
-        uint8 m_swingErrorMsg;
+        AutoAttackCheckResult m_swingErrorMsg;
         float m_ammoDPS;
 
         ////////////////////Rest System/////////////////////

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -463,14 +463,14 @@ bool Unit::UpdateMeleeAttackingState()
             }
             case ATTACK_RESULT_DEAD:
             {
-                AttackStop(false);
-                if (pPlayer && pPlayer->GetLastSwingErrorMsg() != ATTACK_RESULT_CANT_ATTACK)
+                AttackStop(true);
+                if (pPlayer && pPlayer->GetLastSwingErrorMsg() != ATTACK_RESULT_DEAD)
                     pPlayer->SendAttackSwingDeadTarget();
                 break;
             }
             case ATTACK_RESULT_FRIENDLY_TARGET:
             {
-                AttackStop(false);
+                AttackStop(true);
                 if (pPlayer && pPlayer->GetLastSwingErrorMsg() != ATTACK_RESULT_FRIENDLY_TARGET)
                     pPlayer->SendAttackSwingCantAttack();
                 break;

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -551,6 +551,16 @@ enum NPCFlags
     UNIT_NPC_FLAG_OUTDOORPVP            = 0x20000000,       // custom flag for outdoor pvp creatures || Custom flag
 };
 
+enum AutoAttackCheckResult
+{
+    ATTACK_RESULT_OK = 0,
+    ATTACK_RESULT_NOT_IN_RANGE = 1,
+    ATTACK_RESULT_BAD_FACING = 2,
+    ATTACK_RESULT_CANT_ATTACK = 3,
+    ATTACK_RESULT_DEAD = 4,
+    ATTACK_RESULT_FRIENDLY_TARGET = 5,
+};
+
 namespace Movement
 {
     class MoveSpline;
@@ -998,6 +1008,8 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         bool isAttackReady(WeaponAttackType type = BASE_ATTACK) const;
         bool haveOffhandWeapon() const;
         bool UpdateMeleeAttackingState();
+        void DelayAutoAttacks();
+        virtual AutoAttackCheckResult CanAutoAttackTarget(Unit const*) const;
         bool CanUseEquippedWeapon(WeaponAttackType attackType) const
         {
             if (IsInFeralForm())
@@ -1294,7 +1306,6 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         void RemoveFearEffectsByDamageTaken(uint32 damage, uint32 exceptSpellId, DamageEffectType damagetype);
 
         bool IsValidAttackTarget(Unit const* target) const;
-        bool _IsValidAttackTarget(Unit const* target, SpellEntry const* bySpell = nullptr, WorldObject const* obj = nullptr) const;
         bool isTargetableForAttack(bool inversAlive = false, bool isAttackerPlayer = false) const;
         bool isAttackableByAOE(bool requireDeadTarget = false, bool isCasterPlayer = false) const;
         bool isPassiveToHostile() const { return HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PASSIVE); }


### PR DESCRIPTION
Fixes https://github.com/LightsHope/issues/issues/455

The check for friendly target is only done for Players, since mobs already do that on aggro.