### PR TITLE
Fix Warsong Peon AI

### DIFF
--- a/sql/migrations/20180715175204_world.sql
+++ b/sql/migrations/20180715175204_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180715175204');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180715175204');
+-- Add your query below.
+
+-- Warsong Peon
+UPDATE `creature_ai_events` SET `event_type`='0' WHERE `id`=1165601;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
When agroed, the flee movement was being generated before the chase movement breaking this mobs behaviour. Changing event type fixes it.