### PR TITLE
Fix combat distance calculation.

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -6118,7 +6118,7 @@ void Unit::RemoveCharmAuras()
 
 float Unit::GetCombatDistance(const Unit* target) const
 {
-    float radius = target->GetFloatValue(UNIT_FIELD_COMBATREACH) + GetFloatValue(UNIT_FIELD_COMBATREACH);
+    float radius = target->GetObjectBoundingRadius() + GetFloatValue(UNIT_FIELD_COMBATREACH);
     float dx = GetPositionX() - target->GetPositionX();
     float dy = GetPositionY() - target->GetPositionY();
     float dz = GetPositionZ() - target->GetPositionZ();

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -6830,8 +6830,8 @@ SpellCastResult Spell::CheckRange(bool strict)
         }
     }
 
-    //add radius of caster and ~5 yds "give" for non stricred (landing) check
-    float range_mod = strict ? 1.25f : 6.25;
+    // Add up to ~5 yds "give" for non strict (landing) check
+    float range_mod = strict || m_caster->IsCreature() ? 1.25f : 6.25;
 
     // Add leeway bonus if both units are moving
     range_mod += m_caster->GetLeewayBonusRange(target);
@@ -6845,23 +6845,21 @@ SpellCastResult Spell::CheckRange(bool strict)
 
     max_range += range_mod;
 
-    GameObject* go = m_targets.getGOTarget(); // Check range d'un gobj pour crochetage
+    GameObject* go = m_targets.getGOTarget(); // Check range for gobjects (lock picking)
     if (go)
     {
-        // distance from target in checks
         float dist = m_caster->GetDistance(go);
 
         if (dist > max_range)
             return SPELL_FAILED_OUT_OF_RANGE;
     }
+
     if (target && target != m_caster)
     {
-        // distance from target in checks
         float dist = m_caster->GetCombatDistance(target);
 
         if (dist > max_range)
             return SPELL_FAILED_OUT_OF_RANGE;
-            
         if (min_range && dist < min_range)
             return SPELL_FAILED_TOO_CLOSE;
         if (m_caster->GetTypeId() == TYPEID_PLAYER &&

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -6861,6 +6861,7 @@ SpellCastResult Spell::CheckRange(bool strict)
 
         if (dist > max_range)
             return SPELL_FAILED_OUT_OF_RANGE;
+            
         if (min_range && dist < min_range)
             return SPELL_FAILED_TOO_CLOSE;
         if (m_caster->GetTypeId() == TYPEID_PLAYER &&

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -6831,7 +6831,7 @@ SpellCastResult Spell::CheckRange(bool strict)
     }
 
     // Add up to ~5 yds "give" for non strict (landing) check
-    float range_mod = strict || m_caster->IsCreature() ? 1.25f : 6.25;
+    float range_mod = strict ? 1.25f : GetRangeExtensionForCaster();
 
     // Add leeway bonus if both units are moving
     range_mod += m_caster->GetLeewayBonusRange(target);

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -498,8 +498,11 @@ class Spell
         void CancelGlobalCooldown();
 
         void SendLoot(ObjectGuid guid, LootType loottype, LockType lockType);
-        bool IgnoreItemRequirements() const;                        // some item use spells have unexpected reagent data
+        bool IgnoreItemRequirements() const;                // some item use spells have unexpected reagent data
         void UpdateOriginalCasterPointer();
+
+        // Additional range for non-strict check at end of cast
+        inline float GetRangeExtensionForCaster() const { return m_caster->IsPlayer() ? 6.25f : 2.25f; }
 
         Unit* m_caster;
 


### PR DESCRIPTION
Currently the maximum cast distance for spells in the core does not match the one in the client. This means the spell can be red in client, but if you force a CastSpell in core the check in CheckCast will succeed. Using the target's bounding radius instead of their combat reach in the calculation fixes this, and makes the core distance check result match the one done by the client.

Also removed the 5 yard leeway on the end of the cast for creatures. Mobs do not lag, and shouldn't need that. It resulted in mobs being able to get off spells way outside of the maximum cast range of the spell.