### PR TITLE
Fix to Piercing Howl AoE daze effect

### DIFF
--- a/sql/migrations/20180720011623_world.sql
+++ b/sql/migrations/20180720011623_world.sql
@@ -1,0 +1,29 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180720011623');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180720011623');
+-- Add your query below.
+
+REPLACE INTO `spell_mod` (`Id`, `AttributesEx`, `Custom`, `Comment`) VALUES 
+('5101', '-1', '256', 'Daze spell attribute'),
+('5116', '-1', '256', 'Daze spell attribute'),
+('12323', '-1', '256', 'Daze spell attribute'),
+('13496', '-1', '256', 'Daze spell attribute'),
+('17174', '-1', '256', 'Daze spell attribute'),
+('22914', '-1', '256', 'Daze spell attribute'),
+('23600', '-1', '256', 'Daze spell attribute'),
+('26379', '-1', '256', 'Daze spell attribute'),
+('27634', '-1', '256', 'Daze spell attribute');
+
+UPDATE `spell_mod` SET `AttributesEx`='-1', `Custom`='256' WHERE `Id`=15571;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -613,7 +613,7 @@ SpellSpecific GetSpellSpecific(uint32 spellId)
 
     // Movement speed reduction
     // Dazes are not affected
-    if (IsSpellHaveSingleAura(spellInfo, SPELL_AURA_MOD_DECREASE_SPEED) && !(spellInfo->AttributesEx & SPELL_ATTR_EX_UNK18))
+    if (IsSpellHaveSingleAura(spellInfo, SPELL_AURA_MOD_DECREASE_SPEED) && !(spellInfo->Custom & SPELL_CUSTOM_DAZE))
         return SPELL_SNARE;
 
     return SPELL_NORMAL;

--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -56,6 +56,7 @@ enum SpellAttributeCustom
     SPELL_CUSTOM_IGNORE_ARMOR               = 0x020,
     SPELL_CUSTOM_FROM_BEHIND                = 0x040,     // For spells that require the caster to be behind the target
     SPELL_CUSTOM_FROM_FRONT                 = 0x080,     // For spells that require the target to be in front of the caster
+    SPELL_CUSTOM_DAZE                       = 0x100,     // For all daze spells
 };
 
 // only used in code


### PR DESCRIPTION
Apparently giving a spell an AttributeEx makes it a single target spell, changed it to use a SPELL_CUSTOM_DAZE flag instead.