### PR TITLE
Add support for player name output in pin/bani commands

### DIFF
--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -3502,10 +3502,10 @@ std::string ChatHandler::ExtractPlayerNameFromLink(char** text)
  */
 bool ChatHandler::ExtractPlayerTarget(char** args, Player** player /*= NULL*/, ObjectGuid* player_guid /*= NULL*/, std::string* player_name /*= NULL*/, bool use_extended_response)
 {
-	std::string name = "";
+    std::string name = "";
     if (*args && **args)
     {
-		name = ExtractPlayerNameFromLink(args);
+        name = ExtractPlayerNameFromLink(args);
         if (name.empty())
         {
             SendSysMessage(LANG_PLAYER_NOT_FOUND);
@@ -3546,14 +3546,14 @@ bool ChatHandler::ExtractPlayerTarget(char** args, Player** player /*= NULL*/, O
     // some from req. data must be provided (note: name is empty if player not exist)
     if ((!player || !*player) && (!player_guid || !*player_guid) && (!player_name || player_name->empty()))
     {
-		if (use_extended_response && !name.empty()) {
-			std::string message(GetMangosString(LANG_PLAYER_NOT_FOUND));
-			message.append(" (" + name + ")");
-			SendSysMessage(message.c_str());
-		}
-		else {
-			SendSysMessage(LANG_PLAYER_NOT_FOUND);
-		}
+        if (use_extended_response && !name.empty()) {
+            std::string message(GetMangosString(LANG_PLAYER_NOT_FOUND));
+            message.append(" (" + name + ")");
+            SendSysMessage(message.c_str());
+        }
+        else {
+            SendSysMessage(LANG_PLAYER_NOT_FOUND);
+        }
         SetSentErrorMessage(true);
         return false;
     }

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -3546,12 +3546,14 @@ bool ChatHandler::ExtractPlayerTarget(char** args, Player** player /*= NULL*/, O
     // some from req. data must be provided (note: name is empty if player not exist)
     if ((!player || !*player) && (!player_guid || !*player_guid) && (!player_name || player_name->empty()))
     {
-        if (use_extended_response && !name.empty()) {
+        if (use_extended_response && !name.empty())
+        {
             std::string message(GetMangosString(LANG_PLAYER_NOT_FOUND));
             message.append(" (" + name + ")");
             SendSysMessage(message.c_str());
         }
-        else {
+        else
+        {
             SendSysMessage(LANG_PLAYER_NOT_FOUND);
         }
         SetSentErrorMessage(true);

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -3500,11 +3500,12 @@ std::string ChatHandler::ExtractPlayerNameFromLink(char** text)
  *
  * @return           true if extraction successful
  */
-bool ChatHandler::ExtractPlayerTarget(char** args, Player** player /*= NULL*/, ObjectGuid* player_guid /*= NULL*/, std::string* player_name /*= NULL*/)
+bool ChatHandler::ExtractPlayerTarget(char** args, Player** player /*= NULL*/, ObjectGuid* player_guid /*= NULL*/, std::string* player_name /*= NULL*/, bool use_extended_response)
 {
+	std::string name = "";
     if (*args && **args)
     {
-        std::string name = ExtractPlayerNameFromLink(args);
+		name = ExtractPlayerNameFromLink(args);
         if (name.empty())
         {
             SendSysMessage(LANG_PLAYER_NOT_FOUND);
@@ -3545,7 +3546,14 @@ bool ChatHandler::ExtractPlayerTarget(char** args, Player** player /*= NULL*/, O
     // some from req. data must be provided (note: name is empty if player not exist)
     if ((!player || !*player) && (!player_guid || !*player_guid) && (!player_name || player_name->empty()))
     {
-        SendSysMessage(LANG_PLAYER_NOT_FOUND);
+		if (use_extended_response && !name.empty()) {
+			std::string message(GetMangosString(LANG_PLAYER_NOT_FOUND));
+			message.append(" (" + name + ")");
+			SendSysMessage(message.c_str());
+		}
+		else {
+			SendSysMessage(LANG_PLAYER_NOT_FOUND);
+		}
         SetSentErrorMessage(true);
         return false;
     }

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -911,7 +911,7 @@ class MANGOS_DLL_SPEC ChatHandler
         bool   ExtractLocationFromLink(char** text, uint32& mapid, float& x, float& y, float& z);
         bool   ExtractRaceMask(char** text, uint32& raceMask, char const** maskName = nullptr);
         std::string ExtractPlayerNameFromLink(char** text);
-        bool ExtractPlayerTarget(char** args, Player** player, ObjectGuid* player_guid = nullptr, std::string* player_name = nullptr);
+        bool ExtractPlayerTarget(char** args, Player** player, ObjectGuid* player_guid = nullptr, std::string* player_name = nullptr, bool use_extended_response = false);
                                                             // select by arg (name/link) or in-game selection online/offline player
 
         // Utility methods for commands

--- a/src/game/Commands/Level2.cpp
+++ b/src/game/Commands/Level2.cpp
@@ -2487,7 +2487,7 @@ bool ChatHandler::HandlePInfoCommand(char* args)
     Player* target;
     ObjectGuid target_guid;
     std::string target_name;
-    if (!ExtractPlayerTarget(&args, &target, &target_guid, &target_name))
+    if (!ExtractPlayerTarget(&args, &target, &target_guid, &target_name, true))
         return false;
 
     if (HasLowerSecurity(target, target ? ObjectGuid() : target_guid))

--- a/src/game/Commands/Level3.cpp
+++ b/src/game/Commands/Level3.cpp
@@ -5739,7 +5739,7 @@ bool ChatHandler::HandleBanInfoCharacterCommand(char* args)
 {
     Player* target;
     ObjectGuid target_guid;
-    if (!ExtractPlayerTarget(&args, &target, &target_guid))
+    if (!ExtractPlayerTarget(&args, &target, &target_guid,NULL,true))
         return false;
 
     uint32 accountid = target ? target->GetSession()->GetAccountId() : sObjectMgr.GetPlayerAccountIdByGUID(target_guid);


### PR DESCRIPTION
Adds support to return player name in error message when a Pinfo or Ban info command run with a player name finds no matching player