### PR TITLE
Do not spawn rajaxx generals if rajaxx is dead

### DIFF
--- a/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_rajaxx.cpp
+++ b/src/scripts/kalimdor/silithus/ruins_of_ahnqiraj/boss_rajaxx.cpp
@@ -128,7 +128,7 @@ struct boss_rajaxxAI : public ScriptedAI
         m_uiNextWave_Timer = 0;
         m_uiNextWaveIndex = 0;
 
-        if (m_pInstance)
+        if (m_pInstance && m_creature->isAlive())
         {
             for (uint8 waveIndex = 0; waveIndex < WAVE_MAX; ++waveIndex)
                 ResetWave(waveIndex);
@@ -138,7 +138,7 @@ struct boss_rajaxxAI : public ScriptedAI
 
     void ResetWave(uint8 waveIndex)
     {
-        if (!m_pInstance)
+        if (!m_pInstance || !m_creature->isAlive())
             return;
         if (waveIndex >= WAVE_MAX)
             return;


### PR DESCRIPTION
When re-entering aq20, some rajaxx generals respawn even if the boss has already been killed in that instance id.

In boss_rajaxx script Reset() method, it checks for existance of rajaxx's general GUID and if it exists it spawns the whole group. Unfortunately it seems that the order in which generals get loaded in instance_ruins_of_ahnqiraj is nondeterministic which means for some generals, OnCreatureCreate is called, GUID is assigned to be non-zero, and then in the middle boss_rajaxx script gets called and spawns the groups where GUID in instance_ruins_of_ahnqiraj has already been assigned.

I didn't dig too deep to understand exactly the ordering in which OnCreatureCreate gets called for stuff, but I think a good quick fix is to just check if rajaxx is alive. If he has already been killed, there is no reason to spawn his generals.