### PR TITLE
Fix mana leech aoe spells

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -6491,7 +6491,9 @@ SpellCastResult Spell::CheckCast(bool strict)
             }
             case SPELL_AURA_PERIODIC_MANA_LEECH:
             {
-                if (!m_targets.getUnitTarget() && !IsAreaOfEffectSpell(m_spellInfo))
+                if (!m_targets.getUnitTarget() && 
+                        !IsAreaEffectTarget(Targets(m_spellInfo->EffectImplicitTargetA[i])) &&
+                        !IsAreaEffectTarget(Targets(m_spellInfo->EffectImplicitTargetB[i])))
                     return SPELL_FAILED_BAD_IMPLICIT_TARGETS;
 
                 if (m_caster->GetTypeId() != TYPEID_PLAYER || m_CastItem)

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -6491,7 +6491,7 @@ SpellCastResult Spell::CheckCast(bool strict)
             }
             case SPELL_AURA_PERIODIC_MANA_LEECH:
             {
-                if (!m_targets.getUnitTarget())
+                if (!m_targets.getUnitTarget() && !IsAreaOfEffectSpell(m_spellInfo))
                     return SPELL_FAILED_BAD_IMPLICIT_TARGETS;
 
                 if (m_caster->GetTypeId() != TYPEID_PLAYER || m_CastItem)


### PR DESCRIPTION
Currently, AoE spells which cause mana leech always fail in CheckCast on SPELL_FAILED_BAD_IMPLICIT_TARGETS because they do not select a target to cast on. An example is Azuregos' Manastorm. I think we can just add a check here to not return this error code if it's an AoE spell.