### PR TITLE
Fix implementation of Gordunni Cobalt.

### DIFF
--- a/sql/migrations/20180801070248_world.sql
+++ b/sql/migrations/20180801070248_world.sql
@@ -1,0 +1,23 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180801070248');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180801070248');
+-- Add your query below.
+
+
+-- The dirt mounds should be spawned by the shovel.
+DELETE FROM `pool_template` WHERE `entry`=35701;
+DELETE FROM `pool_gameobject` WHERE `pool_entry`=35701;
+DELETE FROM `gameobject` WHERE `id`=144064;
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20180801070248_world.sql
+++ b/sql/migrations/20180801070248_world.sql
@@ -14,6 +14,9 @@ DELETE FROM `pool_template` WHERE `entry`=35701;
 DELETE FROM `pool_gameobject` WHERE `pool_entry`=35701;
 DELETE FROM `gameobject` WHERE `id`=144064;
 
+-- Fix respawn speed of Gordunni Trap. Same as spawntimesecs.
+UPDATE `gameobject_template` SET `data5`=900 WHERE `entry`=144050;
+
 
 -- End of migration.
 END IF;

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -553,7 +553,14 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                 case 19395: // Gordunni Trap
                 {
                     if (unitTarget && unitTarget->GetTypeId() == TYPEID_PLAYER)
-                        unitTarget->CastSpell(unitTarget, urand(0, 1) ? 19394 : 11756, true);
+                    {
+						// If GameObject casting was implemented, or activating a trap actually despawned it, this wouldn't be needed.
+                        if (GameObject* pObject = unitTarget->FindNearestGameObject(144050, INTERACTION_DISTANCE))
+                        {
+                            unitTarget->CastSpell(unitTarget, urand(0, 1) ? 19394 : 11756, true);
+                            pObject->AddObjectToRemoveList();
+                        }
+                    }
 
                     return;
                 }
@@ -562,7 +569,7 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                     m_caster->HandleEmote(EMOTE_ONESHOT_BOW);
                     return;
                 }
-                case 27798: //Nature's Bounty
+                case 27798: // Nature's Bounty
                 {
                     switch(unitTarget->getPowerType())
                     {

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -557,8 +557,10 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                         // If GameObject casting was implemented, or activating a trap actually despawned it, this wouldn't be needed.
                         if (GameObject* pObject = unitTarget->FindNearestGameObject(144050, INTERACTION_DISTANCE))
                         {
-                            unitTarget->CastSpell(unitTarget, urand(0, 1) ? 19394 : 11756, true);
-                            pObject->AddObjectToRemoveList();
+                            if (pObject->HasStaticDBSpawnData())
+                                unitTarget->CastSpell(unitTarget, urand(0, 1) ? 19394 : 11756, true);
+                            else
+                                pObject->AddObjectToRemoveList();
                         }
                     }
 

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -554,7 +554,7 @@ void Spell::EffectDummy(SpellEffectIndex eff_idx)
                 {
                     if (unitTarget && unitTarget->GetTypeId() == TYPEID_PLAYER)
                     {
-						// If GameObject casting was implemented, or activating a trap actually despawned it, this wouldn't be needed.
+                        // If GameObject casting was implemented, or activating a trap actually despawned it, this wouldn't be needed.
                         if (GameObject* pObject = unitTarget->FindNearestGameObject(144050, INTERACTION_DISTANCE))
                         {
                             unitTarget->CastSpell(unitTarget, urand(0, 1) ? 19394 : 11756, true);


### PR DESCRIPTION
The actual dirt mounds that you loot should not have spawns in the database, they are spawned when using the shovel.

http://classicdb.ch/?quest=2987