### PR TITLE
Gizelton's Caravan: Continue to next location if no player arrives.

### DIFF
--- a/sql/migrations/20180802084845_world.sql
+++ b/sql/migrations/20180802084845_world.sql
@@ -1,0 +1,24 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180802084845');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180802084845');
+-- Add your query below.
+
+
+-- Remove custom texts ids for gizelton's caravan.
+DELETE FROM `script_texts` WHERE `entry` IN (-1001000, -1001001, -1001002, -1001003, -1001004, -1001005, -1001006, -1001007, -1001008, -1001009, -1001010, -1001011);
+
+-- These texts should be zone yells.
+UPDATE `broadcast_text` SET `Type`=6 WHERE `ID` IN (7474, 7475);
+
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
According to Wowhead comments, Gizelton's Caravan should continue on its own to the next location if no player picks up the quest within the available time. Currently it just despawns.

https://classicdb.ch/?quest=5943

By Skorpio on 02/10/2008 (Patch 2.3.3)
> After returning to the Gelkis Village, the caravan sets up shop and rests for 10 minutes. Then it departs headed east along the road and stops just outside the entrance to Mannoroc Coven. At this point the quest becomes available for only 4 minutes. If it is not recieved within that period, the caravan continues east along the road and then north past the Kolkar Village and finally west to Kormek's Hut. You have to then wait for the caravan to complete it's circut before you can pick up the quest (which takes approx. 40-60 minutes! depending on the quests being picked up or not along the way).