### PR TITLE
Implement unused spell attributes.

### DIFF
--- a/src/game/Objects/Player.cpp
+++ b/src/game/Objects/Player.cpp
@@ -15181,7 +15181,7 @@ void Player::LoadAura(AuraSaveStruct& s, uint32 timediff)
         return;
     }
 
-    if (s.remaintime != -1 && !IsPositiveSpell(spellproto))
+    if (s.remaintime != -1 && HasRealTimeDuration(spellproto))
     {
         if (timediff > (INT_MAX / IN_MILLISECONDS))
             return;

--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -377,7 +377,7 @@ enum SpellAttributesEx4
 {
     SPELL_ATTR_EX4_IGNORE_RESISTANCES         = 0x00000001,            // 0 From TC 3.3.5, but not present in 1.12 native DBCs. Add it with spell_mod to prevent a spell from being resisted.
     SPELL_ATTR_EX4_UNK1                       = 0x00000002,            // 1 proc on finishing move?
-    SPELL_ATTR_EX4_UNK2                       = 0x00000004,            // 2
+    SPELL_ATTR_EX4_REAL_TIME_DURATION         = 0x00000004,            // 2 aura continues to expire while player is offline
     SPELL_ATTR_EX4_UNK3                       = 0x00000008,            // 3
     SPELL_ATTR_EX4_UNK4                       = 0x00000010,            // 4 This will no longer cause guards to attack on use??
     SPELL_ATTR_EX4_UNK5                       = 0x00000020,            // 5

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -4196,6 +4196,17 @@ void Spell::finish(bool ok)
         m_caster->AttackStop();
         m_caster->InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
     }
+    else if ((m_spellInfo->AttributesEx & SPELL_ATTR_EX_MELEE_COMBAT_START))
+    {
+        // Pets should initiate melee combat on spell with this flag. (Growl)
+        if (Pet* pPet = m_caster->ToPet())
+            if (pPet->AI() && pPet->GetCharmInfo())
+                if (Unit* const pTarget = m_targets.getUnitTarget())
+                {
+                    pPet->GetCharmInfo()->SetIsCommandAttack(true);
+                    pPet->AI()->AttackStart(pTarget);
+                }
+    }
 }
 
 void Spell::SendCastResult(SpellCastResult result)

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -5291,6 +5291,13 @@ SpellCastResult Spell::CheckCast(bool strict)
         if ((m_spellInfo->MaxTargetLevel > 0) && (int32(target->getLevel()) > m_spellInfo->MaxTargetLevel))
             return SPELL_FAILED_HIGHLEVEL;
 
+#if SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_11_2
+        // World of Warcraft Client Patch 1.12.0 (2006-08-22)
+        // - Pickpocket can now be used on targets that are in combat, as long as the rogue remains stealthed.
+        if ((m_spellInfo->AttributesEx & SPELL_ATTR_EX_IS_PICKPOCKET) && target->isInCombat())
+            return SPELL_FAILED_TARGET_IN_COMBAT;
+#endif
+
         bool non_caster_target = target != m_caster && !IsSpellWithCasterSourceTargetsOnly(m_spellInfo);
 
         if (non_caster_target)

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -4091,7 +4091,9 @@ void Aura::HandlePeriodicDamage(bool apply, bool Real)
             }
             case SPELLFAMILY_ROGUE:
             {
-                // Rupture
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_11_2
+                // World of Warcraft Client Patch 1.12.0 (2006-08-22)
+                // - Rupture: Rupture now increases in potency with greater attack power.
                 if (spellProto->IsFitToFamilyMask<CF_ROGUE_RUPTURE>())
                 {
                     // Dmg/tick = $AP*min(0.01*$cp, 0.03) [Like Rip: only the first three CP increase the contribution from AP]
@@ -4102,6 +4104,13 @@ void Aura::HandlePeriodicDamage(bool apply, bool Real)
                         m_modifier.m_amount += int32(caster->GetTotalAttackPowerValue(BASE_ATTACK) * cp / 100);
                     }
                 }
+#elif SUPPORTED_CLIENT_BUILD <= CLIENT_BUILD_1_11_2
+                // World of Warcraft Client Patch 1.12.0 (2006-08-22)
+                // - Garrote: The damage from this ability has been increased. In
+                //   addition, Garrote now increases in potency with greater attack power.
+                if (spellProto->IsFitToFamilyMask<CF_ROGUE_GARROTE>())
+                    return;
+#endif
                 break;
             }
             default:

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -468,9 +468,15 @@ void Spell::EffectSchoolDMG(SpellEffectIndex effect_idx)
                 // Ferocious Bite
                 if (m_spellInfo->IsFitToFamilyMask<CF_DRUID_RIP_BITE>() && m_spellInfo->SpellVisual == 6587)
                 {
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_11_2
+                    // World of Warcraft Client Patch 1.12.0 (2006-08-22)
+                    // - Ferocious Bite: Book of Ferocious Bite (Rank 5) now drops off The
+                    //   Beast in Black Rock Spire. In addition, Ferocious Bite now increases
+                    //   in potency with greater attack power.
                     // ( AP * 3% * combo + energy * 2,7 + damage )
                     if (uint32 combo = ((Player*)m_caster)->GetComboPoints())
                         damage += int32(m_caster->GetTotalAttackPowerValue(BASE_ATTACK) * combo * 0.03f);
+#endif
                     damage += int32(m_caster->GetPower(POWER_ENERGY) * m_spellInfo->DmgMultiplier[effect_idx]);
                     m_caster->SetPower(POWER_ENERGY, 0);
                 }
@@ -478,12 +484,17 @@ void Spell::EffectSchoolDMG(SpellEffectIndex effect_idx)
             }
             case SPELLFAMILY_ROGUE:
             {
-                // Eviscerate
+#if SUPPORTED_CLIENT_BUILD > CLIENT_BUILD_1_11_2
+                // World of Warcraft Client Patch 1.12.0 (2006-08-22)
+                // - Eviscerate: Manual of Eviscerate (Rank 9) now drops off Blackhand
+                //   Assassins in Black Rock Spire.In addition, Eviscerate now increases
+                //   in potency with greater attack power.
                 if (m_spellInfo->IsFitToFamilyMask<CF_ROGUE_EVISCERATE>() && m_caster->GetTypeId() == TYPEID_PLAYER)
                 {
                     if (uint32 combo = ((Player*)m_caster)->GetComboPoints())
                         damage += int32(m_caster->GetTotalAttackPowerValue(BASE_ATTACK) * combo * 0.03f);
                 }
+#endif
                 break;
             }
             case SPELLFAMILY_HUNTER:

--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -535,6 +535,11 @@ inline bool IsTotemSummonSpell(SpellEntry const* spellInfo)
     return spellInfo->Effect[0] >= SPELL_EFFECT_SUMMON_TOTEM_SLOT1 && spellInfo->Effect[0] <= SPELL_EFFECT_SUMMON_TOTEM_SLOT4;
 }
 
+inline bool HasRealTimeDuration(SpellEntry const* spellInfo)
+{
+    return spellInfo->AttributesEx4 & SPELL_ATTR_EX4_REAL_TIME_DURATION;
+}
+
 // Spell effects require a specific power type on the target
 inline bool IsTargetPowerTypeValid(SpellEntry const *spellInfo, Powers powerType)
 {


### PR DESCRIPTION
- Implemented SPELL_ATTR_EX4_REAL_TIME_DURATION (4). 

I was looking through the patch notes when i saw this:
```
World of Warcraft Client Patch 1.12.0 (2006-08-22)
-  The deserter debuff will now continue to expire even while you are offline.
```

I checked the spell in  both 1.12 and 1.11, and the only difference is that in 1.12 it has attributesEx4 = 4. This flag is not used for any other spells in vanilla. In 3.3.5 it seems to be present in all the spells that should have a real time duration, like Dungeon Deserter. Also WowHead uses this attribute for the "Continues while logged out" filter, so it seems it mean that the spell has a real time duration.

- Implemented SPELL_ATTR_EX_MELEE_COMBAT_START for pets. 

Currently this flag is not used in the core, but in the client it makes you start auto attacking after casting a spell with it. I believe it should do the same for pets, based on this:
```
World of Warcraft Client Patch 1.12.0 (2006-08-22)
-  Growl now correctly initiates combat when used by a pet in passive mode.
```
The only difference between the 1.11 version of Growl and the 1.12 version, is that this attribute was added to the spell. So based on the patch notes, it seems it should have the same effect for pets, as it does for players in the client.