### PR TITLE
Fix various remote bank exploits

### DIFF
--- a/src/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/game/Handlers/AuctionHouseHandler.cpp
@@ -322,11 +322,11 @@ void WorldSession::HandleAuctionSellItem(WorldPacket & recv_data)
         return;
     }
 
-	// prevent selling item in bank slot
-	if (_player->IsBankPos(it->GetPos())) {
-		SendAuctionCommandResult(NULL, AUCTION_STARTED, AUCTION_ERR_INVENTORY, EQUIP_ERR_ITEM_NOT_FOUND);
-		return;
-	}
+    // prevent selling item in bank slot
+    if (_player->IsBankPos(it->GetPos())) {
+        SendAuctionCommandResult(NULL, AUCTION_STARTED, AUCTION_ERR_INVENTORY, EQUIP_ERR_ITEM_NOT_FOUND);
+        return;
+    }
 
     // prevent sending bag with items (cheat: can be placed in bag after adding equipped empty bag to auction)
     if (!it)

--- a/src/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/game/Handlers/AuctionHouseHandler.cpp
@@ -322,6 +322,12 @@ void WorldSession::HandleAuctionSellItem(WorldPacket & recv_data)
         return;
     }
 
+	// prevent selling item in bank slot
+	if (_player->IsBankPos(it->GetPos())) {
+		SendAuctionCommandResult(NULL, AUCTION_STARTED, AUCTION_ERR_INVENTORY, EQUIP_ERR_ITEM_NOT_FOUND);
+		return;
+	}
+
     // prevent sending bag with items (cheat: can be placed in bag after adding equipped empty bag to auction)
     if (!it)
     {

--- a/src/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/game/Handlers/AuctionHouseHandler.cpp
@@ -323,7 +323,8 @@ void WorldSession::HandleAuctionSellItem(WorldPacket & recv_data)
     }
 
     // prevent selling item in bank slot
-    if (_player->IsBankPos(it->GetPos())) {
+    if (_player->IsBankPos(it->GetPos())) 
+    {
         SendAuctionCommandResult(NULL, AUCTION_STARTED, AUCTION_ERR_INVENTORY, EQUIP_ERR_ITEM_NOT_FOUND);
         return;
     }

--- a/src/game/Handlers/ItemHandler.cpp
+++ b/src/game/Handlers/ItemHandler.cpp
@@ -538,7 +538,8 @@ void WorldSession::HandleSellItemOpcode(WorldPacket & recv_data)
     }
 
     // prevent selling item in bank slot
-    if (_player->IsBankPos(pItem->GetPos())) {
+    if (_player->IsBankPos(pItem->GetPos())) 
+    {
         _player->SendSellError(SELL_ERR_CANT_SELL_ITEM, pCreature, itemGuid, 0);
         return;
     }

--- a/src/game/Handlers/ItemHandler.cpp
+++ b/src/game/Handlers/ItemHandler.cpp
@@ -537,11 +537,11 @@ void WorldSession::HandleSellItemOpcode(WorldPacket & recv_data)
         return;
     }
 
-	// prevent selling item in bank slot
-	if (_player->IsBankPos(pItem->GetPos())) {
-		_player->SendSellError(SELL_ERR_CANT_SELL_ITEM, pCreature, itemGuid, 0);
-		return;
-	}
+    // prevent selling item in bank slot
+    if (_player->IsBankPos(pItem->GetPos())) {
+        _player->SendSellError(SELL_ERR_CANT_SELL_ITEM, pCreature, itemGuid, 0);
+        return;
+    }
 
     // prevent sell non empty bag by drag-and-drop at vendor's item list
     if (pItem->IsBag() && !((Bag*)pItem)->IsEmpty())
@@ -861,11 +861,11 @@ void WorldSession::HandleAutoStoreBagItemOpcode(WorldPacket & recv_data)
     }
 
     // cheating: check if source bag / item or destination bag is in bank and player can't use bank
-	if (_player->IsBankPos(srcbag, srcslot) || dstbag >= BANK_SLOT_BAG_START && dstbag < BANK_SLOT_BAG_END)
-	{
-		if (!CanUseBank())
-			return;
-	}
+    if (_player->IsBankPos(srcbag, srcslot) || dstbag >= BANK_SLOT_BAG_START && dstbag < BANK_SLOT_BAG_END)
+    {
+        if (!CanUseBank())
+        return;
+    }
 
     uint16 src = pItem->GetPos();
 

--- a/src/game/Handlers/ItemHandler.cpp
+++ b/src/game/Handlers/ItemHandler.cpp
@@ -537,6 +537,12 @@ void WorldSession::HandleSellItemOpcode(WorldPacket & recv_data)
         return;
     }
 
+	// prevent selling item in bank slot
+	if (_player->IsBankPos(pItem->GetPos())) {
+		_player->SendSellError(SELL_ERR_CANT_SELL_ITEM, pCreature, itemGuid, 0);
+		return;
+	}
+
     // prevent sell non empty bag by drag-and-drop at vendor's item list
     if (pItem->IsBag() && !((Bag*)pItem)->IsEmpty())
     {
@@ -853,6 +859,13 @@ void WorldSession::HandleAutoStoreBagItemOpcode(WorldPacket & recv_data)
         _player->SendEquipError(EQUIP_ERR_ITEM_DOESNT_GO_TO_SLOT, NULL, NULL);
         return;
     }
+
+    // cheating: check if source bag / item or destination bag is in bank and player can't use bank
+	if (_player->IsBankPos(srcbag, srcslot) || dstbag >= BANK_SLOT_BAG_START && dstbag < BANK_SLOT_BAG_END)
+	{
+		if (!CanUseBank())
+			return;
+	}
 
     uint16 src = pItem->GetPos();
 

--- a/src/game/Handlers/MailHandler.cpp
+++ b/src/game/Handlers/MailHandler.cpp
@@ -262,11 +262,11 @@ void WorldSession::HandleSendMailCallback(WorldSession::AsyncMailSendRequest* re
             return;
         }
 
-		// prevent sending item from bank slot
-		if (_player->IsBankPos(item->GetPos())) {
-			pl->SendMailResult(0, MAIL_SEND, MAIL_ERR_MAIL_ATTACHMENT_INVALID);
-			return;
-		}
+        // prevent sending item from bank slot
+        if (_player->IsBankPos(item->GetPos())) {
+            pl->SendMailResult(0, MAIL_SEND, MAIL_ERR_MAIL_ATTACHMENT_INVALID);
+            return;
+        }
 
         if (!item->CanBeTraded())
         {

--- a/src/game/Handlers/MailHandler.cpp
+++ b/src/game/Handlers/MailHandler.cpp
@@ -263,7 +263,8 @@ void WorldSession::HandleSendMailCallback(WorldSession::AsyncMailSendRequest* re
         }
 
         // prevent sending item from bank slot
-        if (_player->IsBankPos(item->GetPos())) {
+        if (_player->IsBankPos(item->GetPos())) 
+        {
             pl->SendMailResult(0, MAIL_SEND, MAIL_ERR_MAIL_ATTACHMENT_INVALID);
             return;
         }

--- a/src/game/Handlers/MailHandler.cpp
+++ b/src/game/Handlers/MailHandler.cpp
@@ -262,6 +262,12 @@ void WorldSession::HandleSendMailCallback(WorldSession::AsyncMailSendRequest* re
             return;
         }
 
+		// prevent sending item from bank slot
+		if (_player->IsBankPos(item->GetPos())) {
+			pl->SendMailResult(0, MAIL_SEND, MAIL_ERR_MAIL_ATTACHMENT_INVALID);
+			return;
+		}
+
         if (!item->CanBeTraded())
         {
             pl->SendMailResult(0, MAIL_SEND, MAIL_ERR_MAIL_ATTACHMENT_INVALID);

--- a/src/game/Handlers/TradeHandler.cpp
+++ b/src/game/Handlers/TradeHandler.cpp
@@ -705,11 +705,11 @@ void WorldSession::HandleSetTradeItemOpcode(WorldPacket& recvPacket)
         return;
     }
 
-	// prevent trading item from bank slot
-	if (_player->IsBankPos(bag, slot)) {
-		SendTradeStatus(TRADE_STATUS_TRADE_CANCELED);
-		return;
-	}
+    // prevent trading item from bank slot
+    if (_player->IsBankPos(bag, slot)) {
+        SendTradeStatus(TRADE_STATUS_TRADE_CANCELED);
+        return;
+    }
 
     // prevent place single item into many trade slots using cheating and client bugs
     if (my_trade->HasItem(item->GetObjectGuid()))

--- a/src/game/Handlers/TradeHandler.cpp
+++ b/src/game/Handlers/TradeHandler.cpp
@@ -705,6 +705,12 @@ void WorldSession::HandleSetTradeItemOpcode(WorldPacket& recvPacket)
         return;
     }
 
+	// prevent trading item from bank slot
+	if (_player->IsBankPos(bag, slot)) {
+		SendTradeStatus(TRADE_STATUS_TRADE_CANCELED);
+		return;
+	}
+
     // prevent place single item into many trade slots using cheating and client bugs
     if (my_trade->HasItem(item->GetObjectGuid()))
     {

--- a/src/game/Handlers/TradeHandler.cpp
+++ b/src/game/Handlers/TradeHandler.cpp
@@ -706,7 +706,8 @@ void WorldSession::HandleSetTradeItemOpcode(WorldPacket& recvPacket)
     }
 
     // prevent trading item from bank slot
-    if (_player->IsBankPos(bag, slot)) {
+    if (_player->IsBankPos(bag, slot)) 
+    {
         SendTradeStatus(TRADE_STATUS_TRADE_CANCELED);
         return;
     }


### PR DESCRIPTION
Fixes various methods of getting items out of a player's bank when they are not supposed to. The worst being the one in **WorldSession::HandleAutoStoreBagItemOpcode**, which allows you to deposit / withdraw items from anywhere. The other fixes are in regards to retrieving bank items through mails, vendors, trades, and AH.

Perhaps some more error messages should be sent to the player, but I did my best to follow the style of similar error checking code.