### PR TITLE
Searing Totem rank1 use correct attack spell

### DIFF
--- a/sql/migrations/20180901180323_world.sql
+++ b/sql/migrations/20180901180323_world.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20180901180323');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20180901180323');
+-- Add your query below.
+
+-- Searing totem rank 1 use correct attack spell
+UPDATE `creature_template` SET `spell1`=`3606` WHERE `entry`=`2523`;
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;


### PR DESCRIPTION
Searing Totem rank1 uses the incorrect attack spell (22048) which makes it incorrectly scale with spell power. With this spell rank1 then does more damage than rank4 at greater spell power levels.

Update to use correct attack spell 3606.