### PR TITLE
Fix mobs not slowable while fleeing

### DIFF
--- a/src/game/Movement/FleeingMovementGenerator.cpp
+++ b/src/game/Movement/FleeingMovementGenerator.cpp
@@ -61,6 +61,7 @@ void FleeingMovementGenerator<T>::_setTargetLocation(T &owner)
     Movement::MoveSplineInit init(owner, "FleeingMovementGenerator");
     init.Move(&path);
     init.SetWalk(_forceWalking);
+    _customSpeed = ((Creature*)&owner)->GetFleeingSpeed();
     if (_customSpeed > 0)
         init.SetVelocity(_customSpeed);
     int32 traveltime = init.Launch();
@@ -204,7 +205,6 @@ void TimedFleeingMovementGenerator::Initialize(Unit& owner)
 {
     ASSERT(owner.GetTypeId() == TYPEID_UNIT);
     _forceWalking = true;
-    _customSpeed = ((Creature*)&owner)->GetFleeingSpeed();
     FleeingMovementGenerator<Creature>::Initialize(*((Creature*)&owner));
 }
 


### PR DESCRIPTION
Change where the mob's fleeing speed is grabbed so that slows have an effect.

This is to address https://github.com/LightsHope/issues/issues/953