### PR TITLE
Implement support for preventing loot drops on creatures

### DIFF
--- a/sql/migrations/20190112022745_world.sql
+++ b/sql/migrations/20190112022745_world.sql
@@ -1,0 +1,31 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20190112022745');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20190112022745');
+-- Add your query below.
+
+UPDATE `creature_template`
+    SET `flags_extra` = `flags_extra` | 0x00020000
+    WHERE `entry` IN (
+        12422, -- Death Talon Dragonspawn
+        12460, -- Death Talon Wyrmguard
+        12461, -- Death Talon Overseer
+        12463, -- Death Talon Flamescale
+        12464, -- Death Talon Wyrmkin
+        12467, -- Death Talon Captain
+        13996, -- Blackwing Technician
+        12459, -- Blackwing Warlock
+        12457, -- Blackwing Spellbinder
+        15264 -- Anubisath Sentinel
+    );
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/AI/ScriptedAI.cpp
+++ b/src/game/AI/ScriptedAI.cpp
@@ -393,3 +393,8 @@ void ScriptedAI::DoTeleportAll(float fX, float fY, float fZ, float fO)
             if (i_pl->isAlive())
                 i_pl->TeleportTo(me->GetMapId(), fX, fY, fZ, fO, TELE_TO_NOT_LEAVE_COMBAT);
 }
+
+bool ScriptedAI::FillLoot(Loot* loot, Player* looter) const
+{
+    return false;
+}

--- a/src/game/AI/ScriptedAI.h
+++ b/src/game/AI/ScriptedAI.h
@@ -74,6 +74,9 @@ struct MANGOS_DLL_DECL ScriptedAI : CreatureAI
     // Called at waypoint reached or PointMovement end
     void MovementInform(uint32, uint32) override {}
 
+    // Called when populating the loot table for this creature
+    bool FillLoot(Loot* loot, Player* looter) const override;
+
     //*************
     // Variables
     //*************

--- a/src/game/Objects/Creature.cpp
+++ b/src/game/Objects/Creature.cpp
@@ -179,7 +179,7 @@ Creature::Creature(CreatureSubtype subtype) :
     m_HomeX(0.0f), m_HomeY(0.0f), m_HomeZ(0.0f), m_HomeOrientation(0.0f), m_reactState(REACT_PASSIVE),
     m_CombatDistance(0.0f), _lastDamageTakenForEvade(0), _playerDamageTaken(0), _nonPlayerDamageTaken(0), m_creatureInfo(nullptr),
     m_AI_InitializeOnRespawn(false), m_callForHelpDist(5.0f), m_combatWithZoneState(false), m_startwaypoint(0), m_mountId(0),
-    _isEscortable(false), m_reputationId(-1)
+    _isEscortable(false), m_reputationId(-1), _hasDied(false), _hasDiedAndRespawned(false)
 {
     m_regenTimer = 200;
     m_valuesCount = UNIT_END;
@@ -1343,6 +1343,22 @@ bool Creature::IsTappedBy(Player const* player) const
     return true;
 }
 
+bool Creature::CanHaveLoot(Player const* player) const
+{
+    if (auto map = FindMap())
+    {
+        if (map->IsDungeon())
+        {
+            if (_hasDiedAndRespawned && GetCreatureInfo()->flags_extra & CREATURE_FLAG_EXTRA_SINGLE_LOOT_GENERATION)
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
 void Creature::SaveToDB()
 {
     // this should only be used when the creature has already been loaded
@@ -1794,6 +1810,7 @@ void Creature::SetDeathState(DeathState s)
 {
     if ((s == JUST_DIED && !m_isDeadByDefault) || (s == JUST_ALIVED && m_isDeadByDefault))
     {
+        _hasDied = true;
         auto data = sObjectMgr.GetCreatureData(GetGUIDLow());
 
         uint32 respawnDelay = m_respawnDelay;
@@ -1926,6 +1943,9 @@ void Creature::Respawn()
 
     if (CreatureGroup* group = GetCreatureGroup())
         group->OnRespawn(this);
+
+    if (_hasDied)
+        _hasDiedAndRespawned = true;
 }
 
 void Creature::ForcedDespawn(uint32 timeMSToDespawn)

--- a/src/game/Objects/Creature.h
+++ b/src/game/Objects/Creature.h
@@ -66,6 +66,7 @@ enum CreatureFlagsExtra
     CREATURE_FLAG_EXTRA_IMMUNE_AOE                   = 0x00004000,       // creature is immune to AoE
     CREATURE_FLAG_EXTRA_CHASE_GEN_NO_BACKING         = 0x00008000,       // creature does not move back when target is within bounding radius
     CREATURE_FLAG_EXTRA_NO_ASSIST                    = 0x00010000,       // creature does not aggro when nearby creatures aggro
+    CREATURE_FLAG_EXTRA_SINGLE_LOOT_GENERATION       = 0x00020000        // creature will only generate loot once - no loot after subsequent deaths
 };
 
 // GCC have alternative #pragma pack(N) syntax and old gcc version not support pack(push,N), also any gcc version not support it at some platform
@@ -659,6 +660,7 @@ class MANGOS_DLL_SPEC Creature : public Unit
         Player* GetOriginalLootRecipient() const;           // ignore group changes/etc, not for looting
         bool IsTappedBy(Player const* player) const;
         bool IsSkinnableBy(Player const* player) const { return !skinningForOthersTimer || IsTappedBy(player); }
+        bool CanHaveLoot(Player const* player) const;
 
         SpellEntry const *ReachWithSpellAttack(Unit *pVictim);
         SpellEntry const *ReachWithSpellCure(Unit *pVictim);
@@ -943,6 +945,8 @@ class MANGOS_DLL_SPEC Creature : public Unit
         float m_callForHelpDist;
 
         bool _isEscortable;
+        bool _hasDied;
+        bool _hasDiedAndRespawned;
 
     private:
         GridReference<Creature> m_gridRef;

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -1167,16 +1167,20 @@ void Unit::Kill(Unit* pVictim, SpellEntry const *spellProto, bool durabilityLoss
                 creature->lootForPickPocketed = false;
 
             loot->clear();
-            if (!(creature->AI() && creature->AI()->FillLoot(loot, looter)))
-            {
-                if (uint32 lootid = creature->GetCreatureInfo()->lootid)
-                {
-                    loot->SetTeam(group_tap ? group_tap->GetTeam() : looter->GetTeam());
-                    loot->FillLoot(lootid, LootTemplates_Creature, looter, false, false, creature);
-                }
-            }
 
-            loot->generateMoneyLoot(creature->GetCreatureInfo()->mingold, creature->GetCreatureInfo()->maxgold);
+            if (creature->CanHaveLoot(looter))
+            {
+                if (!(creature->AI() && creature->AI()->FillLoot(loot, looter)))
+                {
+                    if (uint32 lootid = creature->GetCreatureInfo()->lootid)
+                    {
+                        loot->SetTeam(group_tap ? group_tap->GetTeam() : looter->GetTeam());
+                        loot->FillLoot(lootid, LootTemplates_Creature, looter, false, false, creature);
+                    }
+                }
+
+                loot->generateMoneyLoot(creature->GetCreatureInfo()->mingold, creature->GetCreatureInfo()->maxgold);
+            }
         }
 
         if (group_tap)


### PR DESCRIPTION
Currently only affecting certain units which have died and respawned as part of a group reset