### PR TITLE
Now correctly handle rolling immunity effects from multiple auras applying the same immunity

### DIFF
--- a/sql/migrations/20190112151439_world.sql
+++ b/sql/migrations/20190112151439_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20190112151439');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20190112151439');
+-- Add your query below.
+
+-- Add proc ex to Fear Ward so it triggers properly. Note that whether
+-- the spell procs Fear Ward or not is hardcoded, since it depends on
+-- the mechanic type of the proc spell (MECHANIC_FEAR)
+INSERT INTO `spell_proc_event` (`entry`, `procFlags`, `procEx`)
+VALUES (6346, 0x00022000, 1);
+
+-- End of migration.
+END IF;
+END??
+delimiter ; 
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -7060,18 +7060,16 @@ bool Unit::IsImmuneToSpell(SpellEntry const *spellInfo, bool /*castOnSelf*/)
         for (SpellImmuneList::const_iterator itr = mechanicList.begin(); itr != mechanicList.end(); ++itr)
         {
             if (itr->type == mechanic)
-            {
-                // always remove Fear Ward on fear immunity event, even if the unit has another fear immunity aura like Berserker Rage
-                if (mechanic == MECHANIC_FEAR)
-                    RemoveAurasDueToSpell(6346);
                 return true;
-            }
         }
 
+        uint32 mask = 1 << (mechanic - 1);
         AuraList const& immuneAuraApply = GetAurasByType(SPELL_AURA_MECHANIC_IMMUNITY_MASK);
         for (AuraList::const_iterator iter = immuneAuraApply.begin(); iter != immuneAuraApply.end(); ++iter)
-            if ((*iter)->GetModifier()->m_miscvalue & (1 << (mechanic - 1)))
+        {
+            if ((*iter)->GetModifier()->m_miscvalue & mask)
                 return true;
+        }
     }
 
     return false;
@@ -7338,16 +7336,6 @@ void Unit::ApplySpellImmune(uint32 spellId, uint32 op, uint32 type, bool apply)
 {
     if (apply)
     {
-        for (SpellImmuneList::iterator itr = m_spellImmune[op].begin(), next; itr != m_spellImmune[op].end(); itr = next)
-        {
-            next = itr;
-            ++next;
-            if (itr->type == type)
-            {
-                m_spellImmune[op].erase(itr);
-                next = m_spellImmune[op].begin();
-            }
-        }
         SpellImmune Immune;
         Immune.spellId = spellId;
         Immune.type = type;
@@ -7357,7 +7345,7 @@ void Unit::ApplySpellImmune(uint32 spellId, uint32 op, uint32 type, bool apply)
     {
         for (SpellImmuneList::iterator itr = m_spellImmune[op].begin(); itr != m_spellImmune[op].end(); ++itr)
         {
-            if (itr->spellId == spellId)
+            if (itr->spellId == spellId && itr->type == type)
             {
                 m_spellImmune[op].erase(itr);
                 break;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -3838,16 +3838,6 @@ void Aura::HandleModMechanicImmunity(bool apply, bool /*Real*/)
         return;
 
     target->ApplySpellImmune(GetId(), IMMUNITY_MECHANIC, misc, apply);
-
-    // re-apply Fear Ward if it was not wasted during Bersereker Rage
-    if (!apply && GetSpellProto()->IsFitToFamily<SPELLFAMILY_WARRIOR, CF_WARRIOR_BERSERKER_RAGE>())
-    {
-        if (target->HasAura(6346))
-        {
-            auto aura = target->GetAura(6346, EFFECT_INDEX_0);
-            aura->HandleModMechanicImmunity(true, true);
-        }
-    }
 }
 
 void Aura::HandleModMechanicImmunityMask(bool apply, bool /*Real*/)

--- a/src/game/UnitAuraProcHandler.cpp
+++ b/src/game/UnitAuraProcHandler.cpp
@@ -299,6 +299,7 @@ bool Unit::IsTriggeredAtSpellProcEvent(Unit *pVictim, SpellAuraHolder* holder, S
                 return true;
             return false;
         }
+
         // SPELL_AURA_ADD_TARGET_PROC
         // Chance of proc calculated after.
         if (spellProto->EffectApplyAuraName[0] == SPELL_AURA_ADD_TARGET_TRIGGER)
@@ -320,6 +321,19 @@ bool Unit::IsTriggeredAtSpellProcEvent(Unit *pVictim, SpellAuraHolder* holder, S
     }
     // Get proc Event Entry
     spellProcEvent = sSpellMgr.GetSpellProcEvent(spellProto->Id);
+
+    // Custom hard-coded cases which depend on the proc event for firing...
+    if (procSpell)
+    {
+        // Fear Ward always procs on any Fear
+        if (spellProto->Id == 6346)
+        {
+            if (procSpell->Mechanic == MECHANIC_FEAR)
+                return true;
+
+            return false;
+        }
+    }
 
     // Get EventProcFlag
     uint32 EventProcFlag;


### PR DESCRIPTION
- Resolves an issue where using spells such as Death Wish and Recklessness while having Fear Ward active would prevent Fear Ward from functioning after they expire
- Potentially fixes some other behaviour that I've noticed such as effects bypassing Blessing of Freedom if it is used pro-actively
- Also removed (and added some other) kludginess around Fear Ward removal