### PR TITLE
Basic NPC reset command

### DIFF
--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -541,6 +541,7 @@ ChatCommand * ChatHandler::getCommandTable()
         { NODE, "name",           SEC_GAMEMASTER,     false, &ChatHandler::HandleNpcNameCommand,             "", nullptr },
         { NODE, "subname",        SEC_GAMEMASTER,     false, &ChatHandler::HandleNpcSubNameCommand,          "", nullptr },
         //}
+        { NODE, "reset",        SEC_BASIC_ADMIN,      false, &ChatHandler::HandleNpcResetCommand,            "", nullptr },
 
         { MSTR, nullptr,       0,                  false, nullptr,                                           "", nullptr }
     };

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -604,6 +604,7 @@ class MANGOS_DLL_SPEC ChatHandler
         bool HandleNpcFlagCommand(char* args);
         bool HandleNpcFollowCommand(char* args);
         bool HandleNpcInfoCommand(char* args);
+        bool HandleNpcResetCommand(char* args);
         bool HandleNpcMoveCommand(char* args);
         bool HandleNpcPlayEmoteCommand(char* args);
         bool HandleNpcSayCommand(char* args);

--- a/src/game/Commands/Level3.cpp
+++ b/src/game/Commands/Level3.cpp
@@ -4418,12 +4418,9 @@ bool ChatHandler::HandleNpcResetCommand(char* args)
         return false;
     }
 
-    target->SetAInitializeOnRespawn(true);
-
     target->DoKillUnit();
     target->Respawn();
-
-    target->SetAInitializeOnRespawn(false);
+    target->AIM_Initialize();
 
     return true;
 }

--- a/src/game/Commands/Level3.cpp
+++ b/src/game/Commands/Level3.cpp
@@ -4408,6 +4408,26 @@ bool ChatHandler::HandleNpcPlayEmoteCommand(char* args)
     return true;
 }
 
+bool ChatHandler::HandleNpcResetCommand(char* args)
+{
+    auto target = getSelectedCreature();
+    if (!target)
+    {
+        SendSysMessage(LANG_SELECT_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    target->SetAInitializeOnRespawn(true);
+
+    target->DoKillUnit();
+    target->Respawn();
+
+    target->SetAInitializeOnRespawn(false);
+
+    return true;
+}
+
 //TODO: NpcCommands that needs to be fixed :
 
 bool ChatHandler::HandleNpcAddWeaponCommand(char* /*args*/)


### PR DESCRIPTION
Resets the AI of, and repsawns, an NPC.

Useful for GMs when a creature's AI becomes stuck and is not reset by a simple .die and .respawn