### PR TITLE
Classic melee formulas

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2592,11 +2592,11 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit *pVictim, WeaponAttackT
     int32 victimDefenseSkill = pVictim->GetDefenseSkillValue(this);
 
     // bonus from skills is 0.04%
-    int32    skillBonus  = 4 * (attackerWeaponSkill - victimMaxSkillValueForLevel);
+    int32    skillDiff = attackerWeaponSkill - victimMaxSkillValueForLevel;
     int32    cappedSkillDiff = std::min(attackerMaxSkillValueForLevel, attackerWeaponSkill) - victimMaxSkillValueForLevel;
-    int32    blockSkillBonus = pVictim->IsPlayer() ? skillBonus : 10 * cappedSkillDiff;
-    int32    dodgeSkillBonus = pVictim->IsPlayer() ? skillBonus : 10 * cappedSkillDiff;
-    int32    parrySkillBonus = pVictim->IsPlayer() ? skillBonus : 60 * cappedSkillDiff;
+    int32    blockSkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : 10 * skillDiff;
+    int32    dodgeSkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : 10 * skillDiff;
+    int32    parrySkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : 60 * cappedSkillDiff;
     int32    sum = 0, tmp = 0;
     int32    roll = urand(0, 9999);
 
@@ -2888,9 +2888,7 @@ bool Unit::IsSpellBlocked(Unit *pCaster, Unit *pVictim, SpellEntry const *spellE
     float blockChance = GetUnitBlockChance();
 
     int32 skillDiff = int32(pCaster->GetWeaponSkillValue(attackType)) - int32(GetMaxSkillValueForLevel());
-    int32 cappedSkillDiff = std::min(int32(pCaster->GetMaxSkillValueForLevel(this)), int32(pCaster->GetWeaponSkillValue(attackType))) - int32(GetMaxSkillValueForLevel());
-    
-    blockChance -= pVictim->IsPlayer() ? skillDiff * 0.04f : cappedSkillDiff * 0.1f;
+    blockChance -= pVictim->IsPlayer() ? skillDiff * 0.04f : skillDiff * 0.1f;
 
     // Cannot be more than 5%
     if (blockChance > 5) blockChance = 5.0f;
@@ -3035,7 +3033,7 @@ SpellMissInfo Unit::MeleeSpellHitResult(Unit *pVictim, SpellEntry const *spell, 
     if (canDodge)
     {
         // Roll dodge
-        int32 dodgeModifier = pVictim->IsPlayer() ? skillDiff * 4 : cappedSkillDiff * 10;
+        int32 dodgeModifier = pVictim->IsPlayer() ? skillDiff * 4 : skillDiff * 10;
         int32 dodgeChance = int32(pVictim->GetUnitDodgeChance() * 100.0f) - dodgeModifier;
 
         if (dodgeChance < 0)

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2596,7 +2596,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit *pVictim, WeaponAttackT
     int32    cappedSkillDiff = std::min(attackerMaxSkillValueForLevel, attackerWeaponSkill) - victimMaxSkillValueForLevel;
     int32    blockSkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : 10 * skillDiff;
     int32    dodgeSkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : 10 * skillDiff;
-    int32    parrySkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : 60 * cappedSkillDiff;
+    int32    parrySkillBonus = pVictim->IsPlayer() ? 4 * skillDiff : cappedSkillDiff < -10 ? 60 * cappedSkillDiff : 20 * cappedSkillDiff;
     int32    sum = 0, tmp = 0;
     int32    roll = urand(0, 9999);
 
@@ -3051,7 +3051,7 @@ SpellMissInfo Unit::MeleeSpellHitResult(Unit *pVictim, SpellEntry const *spell, 
     if (canParry)
     {
         // Roll parry
-        int32 parryModifier = pVictim->IsPlayer() ? skillDiff * 4 : cappedSkillDiff * 60;
+        int32 parryModifier = pVictim->IsPlayer() ? skillDiff * 4 : cappedSkillDiff < -10 ? 60 * cappedSkillDiff : 20 * cappedSkillDiff;
         int32 parryChance = int32(pVictim->GetUnitParryChance() * 100.0f)  - parryModifier;
 
         // Can`t parry from behind

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -3440,7 +3440,10 @@ float Unit::GetUnitCriticalChance(WeaponAttackType attackType, const Unit *pVict
         crit += pVictim->GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_CHANCE);
 
     // Apply crit chance from defence skill
-    crit += (int32(GetMaxSkillValueForLevel(pVictim)) - int32(pVictim->GetDefenseSkillValue(this))) * 0.04f;
+    int32 skillDiff = int32(GetWeaponSkillValue(attackType, pVictim)) - int32(pVictim->GetDefenseSkillValue(this));
+    int32 cappedSkillDiff = std::min(int32(GetMaxSkillValueForLevel(pVictim)), int32(GetWeaponSkillValue(attackType, pVictim))) - int32(pVictim->GetDefenseSkillValue(this));
+
+    crit += (pVictim->IsPlayer() || skillDiff > 0) ? skillDiff * 0.04f : cappedSkillDiff * 0.2f;
 
     if (crit < 0.0f)
         crit = 0.0f;

--- a/src/game/Objects/Unit.h
+++ b/src/game/Objects/Unit.h
@@ -1703,7 +1703,7 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         uint32 MeleeDamageBonusTaken(Unit *pCaster, uint32 pdamage,WeaponAttackType attType,
             SpellEntry const *spellProto = nullptr, DamageEffectType damagetype = DIRECT_DAMAGE, uint32 stack = 1, Spell* spell = nullptr, bool flat = true);
 
-        bool   IsSpellBlocked(Unit *pCaster, SpellEntry const *spellProto, WeaponAttackType attackType = BASE_ATTACK);
+        bool   IsSpellBlocked(Unit *pCaster, Unit *pVictim, SpellEntry const *spellProto, WeaponAttackType attackType = BASE_ATTACK);
         bool   IsSpellCrit(Unit *pVictim, SpellEntry const *spellProto, SpellSchoolMask schoolMask, WeaponAttackType attackType = BASE_ATTACK, Spell* spell = nullptr);
         uint32 SpellCriticalDamageBonus(SpellEntry const *spellProto, uint32 damage, Unit *pVictim, Spell* spell = nullptr);
         uint32 SpellCriticalHealingBonus(SpellEntry const *spellProto, uint32 damage, Unit *pVictim);


### PR DESCRIPTION
Formulas based on Beaza's writings, the recent blue posts and Classic Beta testing: https://github.com/magey/classic-warrior/wiki/Attack-table

Some things that are still unknown / up to debate:
- How exactly parry scales. I made it a linear 0.6 per skill point so it matches the 14% but the data shows much lower parry than expected on +1 and +2 level mobs.
- Beaza never mentions what he means by "caster" on the glancing formula. I considered caster to be only the wand classes Mage / Lock / Priest.
- I hardcoded the mysterious 1% of hit that gets ignored according to the latest blue post, even though it makes no sense and it could just be the QA person explaining it badly. Let me know if I should remove it. 

